### PR TITLE
:sparkles: feat: 회원가입 시 이메일 인증 코드 전송 기능 구현

### DIFF
--- a/http/email.http
+++ b/http/email.http
@@ -1,0 +1,7 @@
+### 이메일 인증코드 전송
+POST http://localhost:8080/auth/email/send
+Content-Type: application/json
+
+{
+  "email": "rlawldbs9128@gmail.com"
+}

--- a/src/main/java/com/salayo/locallifebackend/domain/email/config/EmailConfig.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/email/config/EmailConfig.java
@@ -1,0 +1,36 @@
+package com.salayo.locallifebackend.domain.email.config;
+
+import java.util.Properties;
+import org.springframework.boot.autoconfigure.mail.MailProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableConfigurationProperties(MailProperties.class)
+@EnableAsync
+public class EmailConfig {
+
+    @Bean
+    public JavaMailSender javaMailSender(MailProperties mailProperties) {
+
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+
+        mailSender.setHost(mailProperties.getHost());
+        mailSender.setPort(mailProperties.getPort());
+        mailSender.setUsername(mailProperties.getUsername());
+        mailSender.setPassword(mailProperties.getPassword());
+
+        Properties properties = mailSender.getJavaMailProperties();
+
+        properties.put("mail.smtp.auth", true);
+        properties.put("mail.smtp.starttls.enable", true);
+        properties.put("mail.smtp.ssl.trust", mailProperties.getHost());
+
+        return mailSender;
+    }
+
+}

--- a/src/main/java/com/salayo/locallifebackend/domain/email/controller/EmailController.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/email/controller/EmailController.java
@@ -1,0 +1,32 @@
+package com.salayo.locallifebackend.domain.email.controller;
+
+import com.salayo.locallifebackend.domain.email.dto.EmailSendRequestDto;
+import com.salayo.locallifebackend.domain.email.service.EmailService;
+import com.salayo.locallifebackend.global.dto.CommonResponseDto;
+import com.salayo.locallifebackend.global.success.SuccessCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth/email")
+@Tag(name = "이메일 관련 기능", description = "이메일 관련 API")
+public class EmailController {
+
+    private final EmailService emailService;
+
+    @PostMapping("/send")
+    @Operation(summary = "회원가입 시 이메일 인증 코드 전송", description = "회원가입 시 사용자의 이메일로 인증 코드를 전송합니다. 인증코드는 5분간 유효합니다.")
+    public ResponseEntity<CommonResponseDto<Void>> sendVerificationCode(@RequestBody EmailSendRequestDto requestDto) {
+        emailService.sendVerificationCode(requestDto.getEmail());
+
+        return ResponseEntity.ok(CommonResponseDto.success(SuccessCode.EMAIL_SEND_SUCCESS, null));
+    }
+
+}

--- a/src/main/java/com/salayo/locallifebackend/domain/email/dto/EmailSendRequestDto.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/email/dto/EmailSendRequestDto.java
@@ -1,0 +1,12 @@
+package com.salayo.locallifebackend.domain.email.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class EmailSendRequestDto {
+
+    private String email;
+
+}

--- a/src/main/java/com/salayo/locallifebackend/domain/email/service/EmailService.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/email/service/EmailService.java
@@ -1,0 +1,49 @@
+package com.salayo.locallifebackend.domain.email.service;
+
+import java.time.Duration;
+import java.util.Random;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+
+    private final JavaMailSender mailSender;
+
+    @Qualifier("emailVerifiedRedisTemplate")
+    private final RedisTemplate<String, String> redisTemplate;
+
+    private static final long EXPIRE_TIME = 5 * 60L;
+
+    public void sendVerificationCode(String email) {
+        String code = generateCode();
+
+        clearVerifiedFlag(email);
+
+        redisTemplate.opsForValue().set("email_code:" + email, code, Duration.ofSeconds(EXPIRE_TIME));
+
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(email);
+        message.setSubject("[LocalLife] 이메일 인증 코드입니다.");
+        message.setText("인증코드: " + code);
+
+        mailSender.send(message);
+        log.info("이메일 전송 완료: {} / 코드: {}", email, code);
+    }
+
+    private String generateCode() {
+        return String.valueOf(new Random().nextInt(900_000) + 100_000);
+    }
+
+    public void clearVerifiedFlag(String email) {
+        redisTemplate.delete("email_verified: " + email);
+    }
+
+}

--- a/src/main/java/com/salayo/locallifebackend/global/config/RedisConfig.java
+++ b/src/main/java/com/salayo/locallifebackend/global/config/RedisConfig.java
@@ -3,6 +3,7 @@ package com.salayo.locallifebackend.global.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
@@ -41,6 +42,15 @@ public class RedisConfig {
 
     @Bean(name = "blacklistRedisTemplate")
     public RedisTemplate<String, String> blacklistRedisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        return redisTemplate;
+    }
+
+    @Bean(name = "emailVerifiedRedisTemplate")
+    public RedisTemplate<String, String> emailVerifiedRedisTemplate(RedisConnectionFactory redisConnectionFactory) {
         RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(redisConnectionFactory);
         redisTemplate.setKeySerializer(new StringRedisSerializer());

--- a/src/main/java/com/salayo/locallifebackend/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/salayo/locallifebackend/global/security/config/SecurityConfig.java
@@ -30,7 +30,7 @@ public class SecurityConfig {
             .httpBasic(AbstractHttpConfigurer::disable)
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers(
-                    "/api/auth/**",
+                    "/auth/**",
                     "/swagger-ui/**",
                     "/api-docs/**",
                     "/swagger-ui.html"

--- a/src/main/java/com/salayo/locallifebackend/global/success/SuccessCode.java
+++ b/src/main/java/com/salayo/locallifebackend/global/success/SuccessCode.java
@@ -11,8 +11,9 @@ public enum SuccessCode {
     UPDATE_SUCCESS(HttpStatus.OK, "성공적으로 수정되었습니다."),
     DELETE_SUCCESS(HttpStatus.OK, "성공적으로 삭제되었습니다."),
 
-    FILE_UPLOAD_SUCCESS(HttpStatus.OK, "파일 업로드 성공");
+    FILE_UPLOAD_SUCCESS(HttpStatus.OK, "파일 업로드 성공"),
 
+    EMAIL_SEND_SUCCESS(HttpStatus.OK,"이메일을 성공적으로 전송했습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -39,3 +39,14 @@ cloud.aws.credentials.secret-key=${AWS_SECRET_KEY}
 cloud.aws.region.static=${AWS_REGION}
 cloud.aws.stack.auto=false
 cloud.aws.s3.bucket=${AWS_S3_BUCKET}
+
+# Email Verification
+spring.mail.host=smtp.gmail.com
+spring.mail.port=587
+spring.mail.username=${MAIL_USERNAME}
+spring.mail.password=${MAIL_PASSWORD}
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls.enable=true
+spring.mail.properties.mail.smtp.ssl.trust=smtp.gmail.com
+spring.mail.properties.mail.debug=true
+logging.level.org.springframework.mail=DEBUG


### PR DESCRIPTION
-SecurityConfig 경로 허용 설정 수정
-이메일 인증용 RedisTemplate 등록
-SMTP 관련 설정 application.properties에 추가
-EmailConfig 통해 JavaMailSender Bean 등록
-EmailController, Service, Dto 구현
-인증 코드 Redis 저장 및 메일 전송 로직 완성