### PR TITLE
✨ feat : ProgramGroup Entity & Repository 생성, Program Entity 단방향 연관관계 추가

### DIFF
--- a/src/main/java/com/salayo/locallifebackend/domain/program/entity/Program.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/program/entity/Program.java
@@ -56,6 +56,10 @@ public class Program extends BaseEntity {
 	@JoinColumn(name = "original_program_id", nullable = true)
 	private Program originalProgram; //원본 프로그램 ID - 자기참조 FK
 
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "program_group_id", nullable = true)
+	private ProgramGroup programGroup; //체험 프로그램 그룹 고유 식별자
+
 	@Column(nullable = false, length = 100)
 	private String businessName; //상호명
 
@@ -120,6 +124,7 @@ public class Program extends BaseEntity {
 
 	@Builder
 	public Program(Member member, AptitudeCategory aptitudeCategory, RegionCategory regionCategory, Program originalProgram,
+		ProgramGroup programGroup,
 		String businessName, String title, String description, String curriculumDescription, String location, BigDecimal price,
 		BigDecimal percent, BigDecimal finalPrice, Integer maxCapacity, Integer minCapacity, LocalDate startDate,
 		LocalDate endDate, Integer count, LocalSpecialized isLocalSpecialized, ProgramStatus programStatus, DeletedStatus deletedStatus,
@@ -128,6 +133,7 @@ public class Program extends BaseEntity {
 		this.aptitudeCategory = aptitudeCategory;
 		this.regionCategory = regionCategory;
 		this.originalProgram = originalProgram;
+		this.programGroup = programGroup;
 		this.businessName = businessName;
 		this.title = title;
 		this.description = description;
@@ -157,7 +163,7 @@ public class Program extends BaseEntity {
 		this.programScheduleTimes.add(programScheduleTime);
 	}
 
-	public void addProgramSchedule(ProgramSchedule programSchedule){
+	public void addProgramSchedule(ProgramSchedule programSchedule) {
 		this.programSchedules.add(programSchedule);
 		programSchedule.connectToProgram(this);
 	}

--- a/src/main/java/com/salayo/locallifebackend/domain/program/entity/ProgramGroup.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/program/entity/ProgramGroup.java
@@ -1,0 +1,26 @@
+package com.salayo.locallifebackend.domain.program.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+@Table(name = "program_group")
+public class ProgramGroup {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id; //체험 프로그램 그룹 고유 식별자
+
+	@Column(nullable = false, length = 100)
+	private String groupTitle; //그룹명
+
+}

--- a/src/main/java/com/salayo/locallifebackend/domain/program/repository/ProgramGroupRepository.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/program/repository/ProgramGroupRepository.java
@@ -1,0 +1,10 @@
+package com.salayo.locallifebackend.domain.program.repository;
+
+import com.salayo.locallifebackend.domain.program.entity.ProgramGroup;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProgramGroupRepository extends JpaRepository<ProgramGroup, Long> {
+
+}


### PR DESCRIPTION

🟪 체험 프로그램을 그룹으로 묶기 위해 `ProgramGroup` Entity 생성
🟪 각 체험 프로그램은 하나의 그룹에만 속할 수 있도록 `Program` Entity에 `@ManyToOne` 단방향 설정