### PR TITLE
:sparkles: feat : 매거진 도메인 엔티티 설계, 관리자 임시등록 API, 카테고리 자동 등록(CommandLineRunner) 구현

### DIFF
--- a/src/main/java/com/salayo/locallifebackend/domain/category/entity/AptitudeCategory.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/category/entity/AptitudeCategory.java
@@ -5,11 +5,14 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
 @Table(name = "aptitude_category")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AptitudeCategory {
 
 	@Id
@@ -19,5 +22,10 @@ public class AptitudeCategory {
 	private String aptitudeName; //적성 이름
 
 	private String aptitudeCode; //적성 코드
+
+	public AptitudeCategory(String aptitudeName, String aptitudeCode) {
+		this.aptitudeName = aptitudeName;
+		this.aptitudeCode = aptitudeCode;
+	}
 
 }

--- a/src/main/java/com/salayo/locallifebackend/domain/category/entity/RegionCategory.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/category/entity/RegionCategory.java
@@ -5,11 +5,14 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
 @Table(name = "region_category")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RegionCategory {
 
 	@Id
@@ -17,4 +20,8 @@ public class RegionCategory {
 	private Long id; //지역 카테고리 고유 식별자
 
 	private String regionName; //지역 이름
+
+	public RegionCategory(String regionName) {
+		this.regionName = regionName;
+	}
 }

--- a/src/main/java/com/salayo/locallifebackend/domain/category/repository/AptitudeCategoryRepository.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/category/repository/AptitudeCategoryRepository.java
@@ -12,4 +12,6 @@ public interface AptitudeCategoryRepository extends JpaRepository<AptitudeCatego
 	default AptitudeCategory findByIdOrElseThrow(Long aptitudeCategoryId){
 		return findById(aptitudeCategoryId).orElseThrow(() -> new CustomException(ErrorCode.APTITUDE_NOT_FOUND));
 	};
+
+	boolean existsByAptitudeCode(String aptitudeCode);
 }

--- a/src/main/java/com/salayo/locallifebackend/domain/category/repository/RegionCategoryRepository.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/category/repository/RegionCategoryRepository.java
@@ -12,4 +12,6 @@ public interface RegionCategoryRepository extends JpaRepository<RegionCategory, 
 	default RegionCategory findByIdOrElseThrow(Long regionCategoryId){
 		return findById(regionCategoryId).orElseThrow(() -> new CustomException(ErrorCode.REGION_NOT_FOUND));
 	};
+
+	boolean existsByRegionName(String regionName);
 }

--- a/src/main/java/com/salayo/locallifebackend/domain/magazine/controller/AdminMagazineController.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/magazine/controller/AdminMagazineController.java
@@ -1,0 +1,42 @@
+package com.salayo.locallifebackend.domain.magazine.controller;
+
+import com.salayo.locallifebackend.domain.magazine.dto.MagazineCreateRequestDto;
+import com.salayo.locallifebackend.domain.magazine.service.MagazineService;
+import com.salayo.locallifebackend.global.dto.CommonResponseDto;
+import com.salayo.locallifebackend.global.security.MemberDetails;
+import com.salayo.locallifebackend.global.success.SuccessCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/admin/magazines")
+@Tag(name = "Admin Magazine", description = "관리자 매거진 관리 API")
+public class AdminMagazineController {
+
+    private final MagazineService magazineService;
+
+    public AdminMagazineController(MagazineService magazineService) {
+        this.magazineService = magazineService;
+    }
+
+    @Operation(summary = "매거진 임시 저장 - 로컬 크리에이터 확인용", description = "관리자가 로컬 크리에이터를 인터뷰한 매거진을 임시 상태로 저장")
+    @PreAuthorize("hasRole('ADMIN')")
+    @PostMapping
+    public ResponseEntity<CommonResponseDto<Void>> createMagazine(
+        @RequestBody @Valid MagazineCreateRequestDto createRequestDto,
+        @AuthenticationPrincipal MemberDetails memberDetails
+        ) {
+        magazineService.createMagazine(createRequestDto, memberDetails.getMember().getId());
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(CommonResponseDto.success(SuccessCode.CREATE_SUCCESS, null));
+    }
+}

--- a/src/main/java/com/salayo/locallifebackend/domain/magazine/dto/MagazineCreateRequestDto.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/magazine/dto/MagazineCreateRequestDto.java
@@ -1,0 +1,27 @@
+package com.salayo.locallifebackend.domain.magazine.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MagazineCreateRequestDto {
+
+    @NotBlank(message = "제목을 입력해주세요.")
+    private String title;
+
+    @NotBlank(message = "본문 내용을 입력해주세요.")
+    private String content;
+
+    @NotNull(message = "지역 카테고리를 선택해주세요.")
+    private Long regionCategoryId;
+
+    @NotNull(message = "적성 카테고리를 선택해주세요.")
+    private Long aptitudeCategoryId;
+
+    @NotBlank(message = "대포 이미지를 등록해주세요.")
+    private String thumbnailUrl;
+
+}

--- a/src/main/java/com/salayo/locallifebackend/domain/magazine/entity/Magazine.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/magazine/entity/Magazine.java
@@ -1,0 +1,96 @@
+package com.salayo.locallifebackend.domain.magazine.entity;
+
+import com.salayo.locallifebackend.domain.category.entity.AptitudeCategory;
+import com.salayo.locallifebackend.domain.category.entity.RegionCategory;
+import com.salayo.locallifebackend.domain.magazine.enums.MagazineStatus;
+import com.salayo.locallifebackend.domain.member.entity.Member;
+import com.salayo.locallifebackend.global.entity.BaseEntity;
+import com.salayo.locallifebackend.global.enums.DeletedStatus;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "magazine")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Magazine extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 255)
+    private String title;
+
+    @Lob
+    @Column(nullable = false)
+    private String content;
+
+    @Column(nullable = false, length = 500)
+    private String thumbnailUrl;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 50)
+    private MagazineStatus magazineStatus;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private DeletedStatus deletedStatus;
+
+    @Column(nullable = false)
+    private Long views;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "region_category_id")
+    private RegionCategory regionCategory;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "aptitude_category_id")
+    private AptitudeCategory aptitudeCategory;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "admin_id")
+    private Member admin;
+
+    @Builder
+    public Magazine(String title, String content, String thumbnailUrl, MagazineStatus magazineStatus, DeletedStatus deletedStatus,
+        Long views, RegionCategory regionCategory, AptitudeCategory aptitudeCategory, Member admin) {
+        this.title = title;
+        this.content = content;
+        this.thumbnailUrl = thumbnailUrl;
+        this.magazineStatus = magazineStatus;
+        this.deletedStatus = deletedStatus;
+        this.views = views;
+        this.regionCategory = regionCategory;
+        this.aptitudeCategory = aptitudeCategory;
+        this.admin = admin;
+    }
+
+    public void updateStatus(MagazineStatus magazineStatus) {
+        this.magazineStatus = magazineStatus;
+    }
+
+    public void increaseViews() {
+        this.views++;
+    }
+
+    public void updateTitleAndContent(String title, String content) {
+        this.title = title;
+        this.content = content;
+    }
+
+}

--- a/src/main/java/com/salayo/locallifebackend/domain/magazine/enums/MagazineStatus.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/magazine/enums/MagazineStatus.java
@@ -1,0 +1,6 @@
+package com.salayo.locallifebackend.domain.magazine.enums;
+
+public enum MagazineStatus {
+    DRAFT,
+    REGISTERED
+}

--- a/src/main/java/com/salayo/locallifebackend/domain/magazine/repository/MagazineRepository.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/magazine/repository/MagazineRepository.java
@@ -1,0 +1,8 @@
+package com.salayo.locallifebackend.domain.magazine.repository;
+
+import com.salayo.locallifebackend.domain.magazine.entity.Magazine;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MagazineRepository extends JpaRepository<Magazine, Long> {
+
+}

--- a/src/main/java/com/salayo/locallifebackend/domain/magazine/service/MagazineService.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/magazine/service/MagazineService.java
@@ -1,0 +1,54 @@
+package com.salayo.locallifebackend.domain.magazine.service;
+
+import com.salayo.locallifebackend.domain.category.entity.AptitudeCategory;
+import com.salayo.locallifebackend.domain.category.entity.RegionCategory;
+import com.salayo.locallifebackend.domain.category.repository.AptitudeCategoryRepository;
+import com.salayo.locallifebackend.domain.category.repository.RegionCategoryRepository;
+import com.salayo.locallifebackend.domain.magazine.dto.MagazineCreateRequestDto;
+import com.salayo.locallifebackend.domain.magazine.entity.Magazine;
+import com.salayo.locallifebackend.domain.magazine.enums.MagazineStatus;
+import com.salayo.locallifebackend.domain.magazine.repository.MagazineRepository;
+import com.salayo.locallifebackend.domain.member.entity.Member;
+import com.salayo.locallifebackend.domain.member.repository.MemberRepository;
+import com.salayo.locallifebackend.global.enums.DeletedStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class MagazineService {
+
+    private final MagazineRepository magazineRepository;
+    private final RegionCategoryRepository regionCategoryRepository;
+    private final AptitudeCategoryRepository aptitudeCategoryRepository;
+    private final MemberRepository memberRepository;
+
+    public MagazineService(MagazineRepository magazineRepository, RegionCategoryRepository regionCategoryRepository,
+        AptitudeCategoryRepository aptitudeCategoryRepository, MemberRepository memberRepository) {
+        this.magazineRepository = magazineRepository;
+        this.regionCategoryRepository = regionCategoryRepository;
+        this.aptitudeCategoryRepository = aptitudeCategoryRepository;
+        this.memberRepository = memberRepository;
+    }
+
+    @Transactional
+    public void createMagazine(MagazineCreateRequestDto createRequestDto, Long adminId) {
+        RegionCategory region = regionCategoryRepository.findByIdOrElseThrow(createRequestDto.getRegionCategoryId());
+        AptitudeCategory aptitude = aptitudeCategoryRepository.findByIdOrElseThrow(createRequestDto.getAptitudeCategoryId());
+        Member admin = memberRepository.findByIdOrElseThrow(adminId);
+
+        Magazine magazine = Magazine.builder()
+            .title(createRequestDto.getTitle())
+            .content(createRequestDto.getContent())
+            .thumbnailUrl(createRequestDto.getThumbnailUrl())
+            .magazineStatus(MagazineStatus.DRAFT)
+            .deletedStatus(DeletedStatus.DISPLAYED)
+            .views(0L)
+            .regionCategory(region)
+            .aptitudeCategory(aptitude)
+            .admin(admin)
+            .build();
+
+        magazineRepository.save(magazine);
+    }
+
+}

--- a/src/main/java/com/salayo/locallifebackend/global/init/CategoryDataInit.java
+++ b/src/main/java/com/salayo/locallifebackend/global/init/CategoryDataInit.java
@@ -1,0 +1,48 @@
+package com.salayo.locallifebackend.global.init;
+
+import com.salayo.locallifebackend.domain.category.entity.AptitudeCategory;
+import com.salayo.locallifebackend.domain.category.entity.RegionCategory;
+import com.salayo.locallifebackend.domain.category.repository.AptitudeCategoryRepository;
+import com.salayo.locallifebackend.domain.category.repository.RegionCategoryRepository;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+@Configuration
+@Profile("local")
+public class CategoryDataInit {
+
+    @Bean
+    public CommandLineRunner initCategoryData(
+        RegionCategoryRepository regionCategoryRepository,
+        AptitudeCategoryRepository aptitudeCategoryRepository
+    ) {
+        return args -> {
+            String[] regionNames = {
+                "서울", "부산", "대구", "인천", "광주", "대전", "울산", "세종",
+                "경기도", "강원도", "충청북도", "충청남도", "전라북도", "전라남도", "경상북도", "경상남도", "제주도"
+            };
+
+            for (String name : regionNames) {
+                if (!regionCategoryRepository.existsByRegionName(name)) {
+                    regionCategoryRepository.save(new RegionCategory(name));
+                }
+            }
+
+            String[][] aptitudes = {
+                {"자연친화", "NATURE"},
+                {"역사문화", "HISTORY_CULTURE"},
+                {"예술창작", "ART"},
+                {"커뮤니티", "COMMUNITY"},
+                {"디지털기술", "TECH"}
+            };
+
+            for (String[] apt : aptitudes) {
+                if (!aptitudeCategoryRepository.existsByAptitudeCode(apt[1])) {
+                    aptitudeCategoryRepository.save(new AptitudeCategory(apt[0], apt[1]));
+                }
+            }
+        };
+    }
+}

--- a/src/main/resources/http/magazine.http
+++ b/src/main/resources/http/magazine.http
@@ -1,0 +1,27 @@
+### 관리자 로그인 - env에 저장된걸로 바꿔서 로그인해주세요
+POST http://localhost:8080/auth/login
+Content-Type: application/json
+
+{
+  "email": "Admin002@salayo.com",
+  "password": "Adminpass1@"
+}
+
+> {%
+  const json = response.body;
+  const accessToken = json.data.accessToken;
+  client.global.set("accessToken", accessToken);
+%}
+
+### 매거진 임시등록 (관리자)
+POST http://localhost:8080/admin/magazines
+Content-Type: application/json
+Authorization: Bearer {{accessToken}}
+
+{
+  "title": "제주 청년 인터뷰, 로컬에서 찾은 꿈",
+  "content": "<h2>로컬 청년의 하루</h2><p>바다와 함께 시작하는 제주에서의 아침...</p><img src=\"https://s3.amazonaws.com/your-bucket/magazine/jeju.jpg\"/>",
+  "regionCategoryId": 1,
+  "aptitudeCategoryId": 2,
+  "thumbnailUrl": "https://s3.amazonaws.com/your-bucket/magazine/jeju-thumb.jpg"
+}


### PR DESCRIPTION
-Magazine 엔티티/DTO/enum/Repository 설계 및 생성
-RegionCategory, AptitudeCategory 엔티티/레포지토리 추가 및 초기 데이터 자동 등록(CommandLineRunner)
-엔티티 생성자 추가, 중복 체크 로직 적용
-개발 환경(local)에서만 자동 등록되도록 profile 분기 처리
-Swagger 문서화 및 테스트용 http 파일 작성