### PR TITLE
✨ feat : 리뷰 기능 전체 CRUD 및 정책 로직 구현

### DIFF
--- a/src/main/java/com/salayo/locallifebackend/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/review/controller/ReviewController.java
@@ -1,17 +1,12 @@
 package com.salayo.locallifebackend.domain.review.controller;
 
-import com.salayo.locallifebackend.domain.program.repository.ProgramRepository;
-import com.salayo.locallifebackend.domain.reservation.repository.ReservationRepository;
-import com.salayo.locallifebackend.domain.reservation.service.ReservationService;
 import com.salayo.locallifebackend.domain.review.dto.ReviewRequestDto;
 import com.salayo.locallifebackend.domain.review.dto.ReviewResponseDto;
 import com.salayo.locallifebackend.domain.review.service.ReviewService;
 import com.salayo.locallifebackend.global.dto.CommonResponseDto;
 import com.salayo.locallifebackend.global.security.MemberDetails;
 import com.salayo.locallifebackend.global.success.SuccessCode;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PageableDefault;
+import java.util.List;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -29,16 +24,9 @@ import org.springframework.web.bind.annotation.RestController;
 public class ReviewController {
 
 	private final ReviewService reviewService;
-	private final ReservationService reservationService;
-	private final ProgramRepository programRepository;
-	private final ReservationRepository reservationRepository;
 
-	public ReviewController(ReviewService reviewService, ReservationService reservationService,
-							ProgramRepository programRepository, ReservationRepository reservationRepository) {
+	public ReviewController(ReviewService reviewService) {
 		this.reviewService = reviewService;
-		this.reservationService = reservationService;
-		this.programRepository = programRepository;
-		this.reservationRepository = reservationRepository;
 	}
 
 	@PostMapping("/programs/{programId}/reviews")
@@ -61,34 +49,30 @@ public class ReviewController {
 
 	@GetMapping("/mypage/reviews")
 	@PreAuthorize("hasRole('USER')")
-	public CommonResponseDto<Page<ReviewResponseDto>> getMyReviews(
-		@AuthenticationPrincipal MemberDetails memberDetails,
-		@PageableDefault(size = 10) Pageable pageable) {
+	public CommonResponseDto<List<ReviewResponseDto>> getMyReviews(
+		@AuthenticationPrincipal MemberDetails memberDetails) {
 
-		Page<ReviewResponseDto> reviews = reviewService.getMyReviews(
-			memberDetails.getMember(),
-			pageable
+		List<ReviewResponseDto> reviews = reviewService.getMyReviews(
+			memberDetails.getMember()
 		);
 
 		return CommonResponseDto.success(SuccessCode.FETCH_SUCCESS, reviews);
 	}
 
 	@GetMapping("/programs/{programId}/reviews")
-	public CommonResponseDto<Page<ReviewResponseDto>> getProgramReviews(
-		@PathVariable Long programId,
-		@PageableDefault(size = 10) Pageable pageable) {
+	public CommonResponseDto<List<ReviewResponseDto>> getProgramReviews(
+		@PathVariable Long programId) {
 
-		Page<ReviewResponseDto> reviews = reviewService.getProgramReviews(programId, pageable);
+		List<ReviewResponseDto> reviews = reviewService.getProgramReviews(programId);
 
 		return CommonResponseDto.success(SuccessCode.FETCH_SUCCESS, reviews);
 	}
 
 	@GetMapping("/admin/reviews")
 	@PreAuthorize("hasRole('ADMIN')")
-	public CommonResponseDto<Page<ReviewResponseDto>> getAllReviews(
-		@PageableDefault(size = 10) Pageable pageable) {
+	public CommonResponseDto<List<ReviewResponseDto>> getAllReviews() {
 
-		Page<ReviewResponseDto> reviews = reviewService.getAllReviews(pageable);
+		List<ReviewResponseDto> reviews = reviewService.getAllReviews();
 
 		return CommonResponseDto.success(SuccessCode.FETCH_SUCCESS, reviews);
 	}

--- a/src/main/java/com/salayo/locallifebackend/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/review/controller/ReviewController.java
@@ -6,6 +6,7 @@ import com.salayo.locallifebackend.domain.review.service.ReviewService;
 import com.salayo.locallifebackend.global.dto.CommonResponseDto;
 import com.salayo.locallifebackend.global.security.MemberDetails;
 import com.salayo.locallifebackend.global.success.SuccessCode;
+import jakarta.validation.Valid;
 import java.util.List;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -15,12 +16,10 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api")
 public class ReviewController {
 
 	private final ReviewService reviewService;
@@ -34,7 +33,7 @@ public class ReviewController {
 	public CommonResponseDto<ReviewResponseDto> createReview(
 		@PathVariable Long programId,
 		@RequestParam Long reservationId,
-		@RequestBody ReviewRequestDto requestDto,
+		@Valid @RequestBody ReviewRequestDto requestDto,
 		@AuthenticationPrincipal MemberDetails memberDetails) {
 
 		ReviewResponseDto responseDto = reviewService.createReview(
@@ -81,7 +80,7 @@ public class ReviewController {
 	@PreAuthorize("hasRole('USER')")
 	public CommonResponseDto<ReviewResponseDto> updateReview(
 		@PathVariable Long reviewId,
-		@RequestBody ReviewRequestDto requestDto,
+		@Valid @RequestBody ReviewRequestDto requestDto,
 		@AuthenticationPrincipal MemberDetails memberDetails) {
 
 		ReviewResponseDto responseDto = reviewService.updateReview(

--- a/src/main/java/com/salayo/locallifebackend/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/review/controller/ReviewController.java
@@ -1,0 +1,122 @@
+package com.salayo.locallifebackend.domain.review.controller;
+
+import com.salayo.locallifebackend.domain.program.repository.ProgramRepository;
+import com.salayo.locallifebackend.domain.reservation.repository.ReservationRepository;
+import com.salayo.locallifebackend.domain.reservation.service.ReservationService;
+import com.salayo.locallifebackend.domain.review.dto.ReviewRequestDto;
+import com.salayo.locallifebackend.domain.review.dto.ReviewResponseDto;
+import com.salayo.locallifebackend.domain.review.service.ReviewService;
+import com.salayo.locallifebackend.global.dto.CommonResponseDto;
+import com.salayo.locallifebackend.global.security.MemberDetails;
+import com.salayo.locallifebackend.global.success.SuccessCode;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+public class ReviewController {
+
+	private final ReviewService reviewService;
+	private final ReservationService reservationService;
+	private final ProgramRepository programRepository;
+	private final ReservationRepository reservationRepository;
+
+	public ReviewController(ReviewService reviewService, ReservationService reservationService,
+							ProgramRepository programRepository, ReservationRepository reservationRepository) {
+		this.reviewService = reviewService;
+		this.reservationService = reservationService;
+		this.programRepository = programRepository;
+		this.reservationRepository = reservationRepository;
+	}
+
+	@PostMapping("/programs/{programId}/reviews")
+	@PreAuthorize("hasRole('USER')")
+	public CommonResponseDto<ReviewResponseDto> createReview(
+		@PathVariable Long programId,
+		@RequestParam Long reservationId,
+		@RequestBody ReviewRequestDto requestDto,
+		@AuthenticationPrincipal MemberDetails memberDetails) {
+
+		ReviewResponseDto responseDto = reviewService.createReview(
+			requestDto,
+			memberDetails.getMember(),
+			programId,
+			reservationId
+		);
+
+		return CommonResponseDto.success(SuccessCode.CREATE_SUCCESS, responseDto);
+	}
+
+	@GetMapping("/mypage/reviews")
+	@PreAuthorize("hasRole('USER')")
+	public CommonResponseDto<Page<ReviewResponseDto>> getMyReviews(
+		@AuthenticationPrincipal MemberDetails memberDetails,
+		@PageableDefault(size = 10) Pageable pageable) {
+
+		Page<ReviewResponseDto> reviews = reviewService.getMyReviews(
+			memberDetails.getMember(),
+			pageable
+		);
+
+		return CommonResponseDto.success(SuccessCode.FETCH_SUCCESS, reviews);
+	}
+
+	@GetMapping("/programs/{programId}/reviews")
+	public CommonResponseDto<Page<ReviewResponseDto>> getProgramReviews(
+		@PathVariable Long programId,
+		@PageableDefault(size = 10) Pageable pageable) {
+
+		Page<ReviewResponseDto> reviews = reviewService.getProgramReviews(programId, pageable);
+
+		return CommonResponseDto.success(SuccessCode.FETCH_SUCCESS, reviews);
+	}
+
+	@GetMapping("/admin/reviews")
+	@PreAuthorize("hasRole('ADMIN')")
+	public CommonResponseDto<Page<ReviewResponseDto>> getAllReviews(
+		@PageableDefault(size = 10) Pageable pageable) {
+
+		Page<ReviewResponseDto> reviews = reviewService.getAllReviews(pageable);
+
+		return CommonResponseDto.success(SuccessCode.FETCH_SUCCESS, reviews);
+	}
+
+	@PutMapping("/reviews/{reviewId}")
+	@PreAuthorize("hasRole('USER')")
+	public CommonResponseDto<ReviewResponseDto> updateReview(
+		@PathVariable Long reviewId,
+		@RequestBody ReviewRequestDto requestDto,
+		@AuthenticationPrincipal MemberDetails memberDetails) {
+
+		ReviewResponseDto responseDto = reviewService.updateReview(
+			reviewId,
+			requestDto,
+			memberDetails.getMember()
+		);
+
+		return CommonResponseDto.success(SuccessCode.UPDATE_SUCCESS, responseDto);
+	}
+
+	@DeleteMapping("/reviews/{reviewId}")
+	@PreAuthorize("hasRole('USER')")
+	public CommonResponseDto<String> deleteReview(
+		@PathVariable Long reviewId,
+		@AuthenticationPrincipal MemberDetails memberDetails) {
+
+		reviewService.deleteReview(reviewId, memberDetails.getMember());
+
+		return CommonResponseDto.success(SuccessCode.DELETE_SUCCESS, "리뷰가 삭제되었습니다.");
+	}
+}

--- a/src/main/java/com/salayo/locallifebackend/domain/review/controller/ReviewReplyController.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/review/controller/ReviewReplyController.java
@@ -6,16 +6,15 @@ import com.salayo.locallifebackend.domain.review.service.ReviewReplyService;
 import com.salayo.locallifebackend.global.dto.CommonResponseDto;
 import com.salayo.locallifebackend.global.security.MemberDetails;
 import com.salayo.locallifebackend.global.success.SuccessCode;
+import jakarta.validation.Valid;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api")
 public class ReviewReplyController {
 
 	private final ReviewReplyService reviewReplyService;

--- a/src/main/java/com/salayo/locallifebackend/domain/review/controller/ReviewReplyController.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/review/controller/ReviewReplyController.java
@@ -1,0 +1,42 @@
+package com.salayo.locallifebackend.domain.review.controller;
+
+import com.salayo.locallifebackend.domain.review.dto.ReviewReplyRequestDto;
+import com.salayo.locallifebackend.domain.review.dto.ReviewReplyResponseDto;
+import com.salayo.locallifebackend.domain.review.service.ReviewReplyService;
+import com.salayo.locallifebackend.global.dto.CommonResponseDto;
+import com.salayo.locallifebackend.global.security.MemberDetails;
+import com.salayo.locallifebackend.global.success.SuccessCode;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+public class ReviewReplyController {
+
+	private final ReviewReplyService reviewReplyService;
+
+	public ReviewReplyController(ReviewReplyService reviewReplyService) {
+		this.reviewReplyService = reviewReplyService;
+	}
+
+	@PostMapping("/reviews/{reviewId}/replies")
+	@PreAuthorize("hasRole('LOCAL_CREATOR')")
+	public CommonResponseDto<ReviewReplyResponseDto> createReviewReply(
+		@PathVariable Long reviewId,
+		@RequestBody ReviewReplyRequestDto requestDto,
+		@AuthenticationPrincipal MemberDetails memberDetails) {
+
+		ReviewReplyResponseDto responseDto = reviewReplyService.createReviewReply(
+			reviewId,
+			requestDto,
+			memberDetails.getMember()
+		);
+
+		return CommonResponseDto.success(SuccessCode.CREATE_SUCCESS, responseDto);
+	}
+}

--- a/src/main/java/com/salayo/locallifebackend/domain/review/dto/ReviewReplyRequestDto.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/review/dto/ReviewReplyRequestDto.java
@@ -1,10 +1,15 @@
 package com.salayo.locallifebackend.domain.review.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
 public class ReviewReplyRequestDto {
+	
+	@NotBlank(message = "답글 내용은 필수입니다.")
+	@Size(max = 500, message = "답글은 최대 500자까지 작성 가능합니다.")
 	private String content;
 }

--- a/src/main/java/com/salayo/locallifebackend/domain/review/dto/ReviewReplyRequestDto.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/review/dto/ReviewReplyRequestDto.java
@@ -1,0 +1,10 @@
+package com.salayo.locallifebackend.domain.review.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ReviewReplyRequestDto {
+	private String content;
+}

--- a/src/main/java/com/salayo/locallifebackend/domain/review/dto/ReviewReplyResponseDto.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/review/dto/ReviewReplyResponseDto.java
@@ -1,0 +1,21 @@
+package com.salayo.locallifebackend.domain.review.dto;
+
+import com.salayo.locallifebackend.domain.review.entity.ReviewReply;
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Getter
+public class ReviewReplyResponseDto {
+
+	private final Long replyId;
+	private final String creatorNickname;
+	private final String content;
+	private final LocalDateTime createdAt;
+
+	public ReviewReplyResponseDto(ReviewReply reviewReply) {
+		this.replyId = reviewReply.getId();
+		this.creatorNickname = reviewReply.getMember().getNickname();
+		this.content = reviewReply.getContent();
+		this.createdAt = reviewReply.getCreatedAt();
+	}
+}

--- a/src/main/java/com/salayo/locallifebackend/domain/review/dto/ReviewRequestDto.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/review/dto/ReviewRequestDto.java
@@ -1,0 +1,10 @@
+package com.salayo.locallifebackend.domain.review.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ReviewRequestDto {
+	private String content;
+}

--- a/src/main/java/com/salayo/locallifebackend/domain/review/dto/ReviewRequestDto.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/review/dto/ReviewRequestDto.java
@@ -1,10 +1,15 @@
 package com.salayo.locallifebackend.domain.review.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
 public class ReviewRequestDto {
+	
+	@NotBlank(message = "리뷰 내용은 필수입니다.")
+	@Size(max = 500, message = "리뷰는 최대 500자까지 작성 가능합니다.")
 	private String content;
 }

--- a/src/main/java/com/salayo/locallifebackend/domain/review/dto/ReviewResponseDto.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/review/dto/ReviewResponseDto.java
@@ -1,0 +1,35 @@
+package com.salayo.locallifebackend.domain.review.dto;
+
+import com.salayo.locallifebackend.domain.review.entity.Review;
+import com.salayo.locallifebackend.domain.review.enums.ReviewStatus;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.Getter;
+
+@Getter
+public class ReviewResponseDto {
+	private final Long reviewId;
+	private final String memberNickname;
+	private final String programTitle;
+	private final LocalDate experienceEndDate;
+	private final String content;
+	private final boolean isModified;
+	private final LocalDateTime createdAt;
+	private final List<ReviewReplyResponseDto> replies;
+
+	public ReviewResponseDto(Review review) {
+		this.reviewId = review.getId();
+		this.memberNickname = review.getMember().getNickname();
+		this.programTitle = review.getProgram().getTitle();
+		this.experienceEndDate = review.getReservation().getEndDate();
+		this.content = review.getContent();
+		this.isModified = review.isModified();
+		this.createdAt = review.getCreatedAt();
+		this.replies = review.getReplies().stream()
+			.filter(reply -> reply.getStatus() == ReviewStatus.DISPLAYED)
+			.map(ReviewReplyResponseDto::new)
+			.collect(Collectors.toList());
+	}
+}

--- a/src/main/java/com/salayo/locallifebackend/domain/review/dto/ReviewResponseDto.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/review/dto/ReviewResponseDto.java
@@ -23,7 +23,7 @@ public class ReviewResponseDto {
 		this.reviewId = review.getId();
 		this.memberNickname = review.getMember().getNickname();
 		this.programTitle = review.getProgram().getTitle();
-		this.experienceEndDate = review.getReservation().getEndDate();
+		this.experienceEndDate = review.getProgram().getEndDate();
 		this.content = review.getContent();
 		this.isModified = review.isModified();
 		this.createdAt = review.getCreatedAt();

--- a/src/main/java/com/salayo/locallifebackend/domain/review/dto/ReviewResponseDto.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/review/dto/ReviewResponseDto.java
@@ -28,7 +28,7 @@ public class ReviewResponseDto {
 		this.isModified = review.isModified();
 		this.createdAt = review.getCreatedAt();
 		this.replies = review.getReplies().stream()
-			.filter(reply -> reply.getStatus() == ReviewStatus.DISPLAYED)
+			.filter(reply -> reply.getReviewStatus() == ReviewStatus.DISPLAYED)
 			.map(ReviewReplyResponseDto::new)
 			.collect(Collectors.toList());
 	}

--- a/src/main/java/com/salayo/locallifebackend/domain/review/dto/ReviewResponseDto.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/review/dto/ReviewResponseDto.java
@@ -1,7 +1,7 @@
 package com.salayo.locallifebackend.domain.review.dto;
 
 import com.salayo.locallifebackend.domain.review.entity.Review;
-import com.salayo.locallifebackend.domain.review.enums.ReviewStatus;
+import com.salayo.locallifebackend.global.enums.DeletedStatus;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -10,6 +10,7 @@ import lombok.Getter;
 
 @Getter
 public class ReviewResponseDto {
+
 	private final Long reviewId;
 	private final String memberNickname;
 	private final String programTitle;
@@ -28,7 +29,7 @@ public class ReviewResponseDto {
 		this.isModified = review.isModified();
 		this.createdAt = review.getCreatedAt();
 		this.replies = review.getReplies().stream()
-			.filter(reply -> reply.getReviewStatus() == ReviewStatus.DISPLAYED)
+			.filter(reply -> reply.getDeletedStatus() == DeletedStatus.DISPLAYED)
 			.map(ReviewReplyResponseDto::new)
 			.collect(Collectors.toList());
 	}

--- a/src/main/java/com/salayo/locallifebackend/domain/review/entity/Review.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/review/entity/Review.java
@@ -79,6 +79,6 @@ public class Review extends BaseEntity {
 	}
 
 	public boolean isModified() {
-		return getUpdatedAt() != null && getUpdatedAt().isAfter(getCreatedAt());
+		return getModifiedAt() != null && getModifiedAt().isAfter(getCreatedAt());
 	}
 }

--- a/src/main/java/com/salayo/locallifebackend/domain/review/entity/Review.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/review/entity/Review.java
@@ -1,0 +1,84 @@
+package com.salayo.locallifebackend.domain.review.entity;
+
+import com.salayo.locallifebackend.domain.member.entity.Member;
+import com.salayo.locallifebackend.domain.program.entity.Program;
+import com.salayo.locallifebackend.domain.reservation.entity.Reservation;
+import com.salayo.locallifebackend.domain.review.enums.ReviewStatus;
+import com.salayo.locallifebackend.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "review")
+@Getter
+@NoArgsConstructor
+public class Review extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "review_id")
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id", nullable = false)
+	private Member member;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "program_id", nullable = false)
+	private Program program;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "reservation_id", nullable = false)
+	private Reservation reservation;
+
+	@Column(columnDefinition = "TEXT", nullable = false)
+	private String content;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "review_status", nullable = false)
+	private ReviewStatus reviewStatus = ReviewStatus.DISPLAYED;
+
+	@Column(name = "deleted_at")
+	private LocalDateTime deletedAt;
+
+	@OneToMany(mappedBy = "review", fetch = FetchType.LAZY)
+	private List<ReviewReply> replies = new ArrayList<>();
+
+	@Builder
+	public Review(Member member, Program program, Reservation reservation, String content) {
+		this.member = member;
+		this.program = program;
+		this.reservation = reservation;
+		this.content = content;
+		this.reviewStatus = ReviewStatus.DISPLAYED;
+	}
+
+	public void updateContent(String content) {
+		this.content = content;
+	}
+
+	public void deleteReview() {
+		this.reviewStatus = ReviewStatus.DELETED;
+		this.deletedAt = LocalDateTime.now();
+	}
+
+	public boolean isModified() {
+		return getUpdatedAt() != null && getUpdatedAt().isAfter(getCreatedAt());
+	}
+}

--- a/src/main/java/com/salayo/locallifebackend/domain/review/entity/Review.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/review/entity/Review.java
@@ -3,8 +3,8 @@ package com.salayo.locallifebackend.domain.review.entity;
 import com.salayo.locallifebackend.domain.member.entity.Member;
 import com.salayo.locallifebackend.domain.program.entity.Program;
 import com.salayo.locallifebackend.domain.reservation.entity.Reservation;
-import com.salayo.locallifebackend.domain.review.enums.ReviewStatus;
 import com.salayo.locallifebackend.global.entity.BaseEntity;
+import com.salayo.locallifebackend.global.enums.DeletedStatus;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -51,8 +51,8 @@ public class Review extends BaseEntity {
 	private String content;
 
 	@Enumerated(EnumType.STRING)
-	@Column(name = "review_status", nullable = false)
-	private ReviewStatus reviewStatus = ReviewStatus.DISPLAYED;
+	@Column(name = "deleted_status", nullable = false)
+	private DeletedStatus deletedStatus = DeletedStatus.DISPLAYED;
 
 	@Column(name = "deleted_at")
 	private LocalDateTime deletedAt;
@@ -66,7 +66,7 @@ public class Review extends BaseEntity {
 		this.program = program;
 		this.reservation = reservation;
 		this.content = content;
-		this.reviewStatus = ReviewStatus.DISPLAYED;
+		this.deletedStatus = DeletedStatus.DISPLAYED;
 	}
 
 	public void updateContent(String content) {
@@ -74,14 +74,15 @@ public class Review extends BaseEntity {
 	}
 
 	public void deleteReview() {
-		this.reviewStatus = ReviewStatus.DELETED;
+		this.deletedStatus = DeletedStatus.DELETED;
 		this.deletedAt = LocalDateTime.now();
 	}
 
 	public boolean isModified() {
 		// modifiedAt이 null이면 수정되지 않은 것으로 간주
-		if (getModifiedAt() == null)
+		if (getModifiedAt() == null) {
 			return false;
+		}
 
 		// createdAt과 modifiedAt이 정확히 같거나, modifiedAt이 createdAt보다 먼저이면 수정되지 않은 것으로 간주
 		// (BaseEntity의 @CreatedDate, @LastModifiedDate 설정에 따라 createdAt과 modifiedAt이 동일하게 초기화될 수 있음)

--- a/src/main/java/com/salayo/locallifebackend/domain/review/entity/ReviewReply.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/review/entity/ReviewReply.java
@@ -43,7 +43,7 @@ public class ReviewReply extends BaseEntity {
 
 	@Enumerated(EnumType.STRING)
 	@Column(name = "reply_status", nullable = false)
-	private ReviewStatus status = ReviewStatus.DISPLAYED;
+	private ReviewStatus reviewStatus = ReviewStatus.DISPLAYED;
 
 	@Column(name = "deleted_at")
 	private LocalDateTime deletedAt;
@@ -53,11 +53,11 @@ public class ReviewReply extends BaseEntity {
 		this.review = review;
 		this.member = member;
 		this.content = content;
-		this.status = ReviewStatus.DISPLAYED;
+		this.reviewStatus = ReviewStatus.DISPLAYED;
 	}
 
 	public void deleteReply() {
-		this.status = ReviewStatus.DELETED;
+		this.reviewStatus = ReviewStatus.DELETED;
 		this.deletedAt = LocalDateTime.now();
 	}
 }

--- a/src/main/java/com/salayo/locallifebackend/domain/review/entity/ReviewReply.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/review/entity/ReviewReply.java
@@ -1,0 +1,63 @@
+package com.salayo.locallifebackend.domain.review.entity;
+
+import com.salayo.locallifebackend.domain.member.entity.Member;
+import com.salayo.locallifebackend.domain.review.enums.ReviewStatus;
+import com.salayo.locallifebackend.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "review_replies")
+@Getter
+@NoArgsConstructor
+public class ReviewReply extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "reply_id")
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "review_id", nullable = false)
+	private Review review;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "local_creator_id", nullable = false)
+	private Member member;
+
+	@Column(columnDefinition = "TEXT", nullable = false)
+	private String content;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "reply_status", nullable = false)
+	private ReviewStatus status = ReviewStatus.DISPLAYED;
+
+	@Column(name = "deleted_at")
+	private LocalDateTime deletedAt;
+
+	@Builder
+	public ReviewReply(Review review, Member member, String content) {
+		this.review = review;
+		this.member = member;
+		this.content = content;
+		this.status = ReviewStatus.DISPLAYED;
+	}
+
+	public void deleteReply() {
+		this.status = ReviewStatus.DELETED;
+		this.deletedAt = LocalDateTime.now();
+	}
+}

--- a/src/main/java/com/salayo/locallifebackend/domain/review/entity/ReviewReply.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/review/entity/ReviewReply.java
@@ -3,6 +3,7 @@ package com.salayo.locallifebackend.domain.review.entity;
 import com.salayo.locallifebackend.domain.member.entity.Member;
 import com.salayo.locallifebackend.domain.review.enums.ReviewStatus;
 import com.salayo.locallifebackend.global.entity.BaseEntity;
+import com.salayo.locallifebackend.global.enums.DeletedStatus;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -42,8 +43,8 @@ public class ReviewReply extends BaseEntity {
 	private String content;
 
 	@Enumerated(EnumType.STRING)
-	@Column(name = "reply_status", nullable = false)
-	private ReviewStatus reviewStatus = ReviewStatus.DISPLAYED;
+	@Column(name = "deleted_status", nullable = false)
+	private DeletedStatus deletedStatus = DeletedStatus.DISPLAYED;
 
 	@Column(name = "deleted_at")
 	private LocalDateTime deletedAt;
@@ -53,11 +54,11 @@ public class ReviewReply extends BaseEntity {
 		this.review = review;
 		this.member = member;
 		this.content = content;
-		this.reviewStatus = ReviewStatus.DISPLAYED;
+		this.deletedStatus = DeletedStatus.DISPLAYED;
 	}
 
 	public void deleteReply() {
-		this.reviewStatus = ReviewStatus.DELETED;
+		this.deletedStatus = DeletedStatus.DELETED;
 		this.deletedAt = LocalDateTime.now();
 	}
 }

--- a/src/main/java/com/salayo/locallifebackend/domain/review/entity/ReviewReply.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/review/entity/ReviewReply.java
@@ -1,7 +1,6 @@
 package com.salayo.locallifebackend.domain.review.entity;
 
 import com.salayo.locallifebackend.domain.member.entity.Member;
-import com.salayo.locallifebackend.domain.review.enums.ReviewStatus;
 import com.salayo.locallifebackend.global.entity.BaseEntity;
 import com.salayo.locallifebackend.global.enums.DeletedStatus;
 import jakarta.persistence.Column;
@@ -57,6 +56,7 @@ public class ReviewReply extends BaseEntity {
 		this.deletedStatus = DeletedStatus.DISPLAYED;
 	}
 
+	// 답글 개별 삭제 기능 확장을 대비해 남겨 둠
 	public void deleteReply() {
 		this.deletedStatus = DeletedStatus.DELETED;
 		this.deletedAt = LocalDateTime.now();

--- a/src/main/java/com/salayo/locallifebackend/domain/review/enums/ReviewStatus.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/review/enums/ReviewStatus.java
@@ -1,0 +1,7 @@
+package com.salayo.locallifebackend.domain.review.enums;
+
+public enum ReviewStatus {
+
+	DISPLAYED, // 게시 중
+	DELETED;  // 삭제 됨
+}

--- a/src/main/java/com/salayo/locallifebackend/domain/review/enums/ReviewStatus.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/review/enums/ReviewStatus.java
@@ -1,7 +1,0 @@
-package com.salayo.locallifebackend.domain.review.enums;
-
-public enum ReviewStatus {
-
-	DISPLAYED, // 게시 중
-	DELETED;  // 삭제 됨
-}

--- a/src/main/java/com/salayo/locallifebackend/domain/review/repository/ReviewReplyRepository.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/review/repository/ReviewReplyRepository.java
@@ -13,12 +13,12 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ReviewReplyRepository extends JpaRepository<ReviewReply, Long> {
 
-	boolean existsByReviewAndStatus(Review review, ReviewStatus status);
+	boolean existsByReviewAndReviewStatus(Review review, ReviewStatus reviewStatus);
 
-	Optional<ReviewReply> findByReviewAndStatus(Review review, ReviewStatus status);
+	Optional<ReviewReply> findByReviewAndReviewStatus(Review review, ReviewStatus reviewStatus);
 
 	@Modifying
-	@Query("UPDATE ReviewReply r SET r.status = com.salayo.locallifebackend.domain.review.enums.ReviewStatus.DELETED, r.deletedAt = CURRENT_TIMESTAMP WHERE r.review = :review")
+	@Query("UPDATE ReviewReply r SET r.reviewStatus = com.salayo.locallifebackend.domain.review.enums.ReviewStatus.DELETED, r.deletedAt = CURRENT_TIMESTAMP WHERE r.review = :review")
 	void softDeleteByReview(@Param("review") Review review);
 
 }

--- a/src/main/java/com/salayo/locallifebackend/domain/review/repository/ReviewReplyRepository.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/review/repository/ReviewReplyRepository.java
@@ -2,7 +2,7 @@ package com.salayo.locallifebackend.domain.review.repository;
 
 import com.salayo.locallifebackend.domain.review.entity.Review;
 import com.salayo.locallifebackend.domain.review.entity.ReviewReply;
-import com.salayo.locallifebackend.domain.review.enums.ReviewStatus;
+import com.salayo.locallifebackend.global.enums.DeletedStatus;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -13,12 +13,12 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ReviewReplyRepository extends JpaRepository<ReviewReply, Long> {
 
-	boolean existsByReviewAndReviewStatus(Review review, ReviewStatus reviewStatus);
+	boolean existsByReviewAndDeletedStatus(Review review, DeletedStatus deletedStatus);
 
-	Optional<ReviewReply> findByReviewAndReviewStatus(Review review, ReviewStatus reviewStatus);
+	Optional<ReviewReply> findByReviewAndDeletedStatus(Review review, DeletedStatus deletedStatus);
 
 	@Modifying
-	@Query("UPDATE ReviewReply r SET r.reviewStatus = com.salayo.locallifebackend.domain.review.enums.ReviewStatus.DELETED, r.deletedAt = CURRENT_TIMESTAMP WHERE r.review = :review")
+	@Query("UPDATE ReviewReply r SET r.deletedStatus = com.salayo.locallifebackend.global.enums.DeletedStatus.DELETED, r.deletedAt = CURRENT_TIMESTAMP WHERE r.review = :review")
 	void softDeleteByReview(@Param("review") Review review);
 
 }

--- a/src/main/java/com/salayo/locallifebackend/domain/review/repository/ReviewReplyRepository.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/review/repository/ReviewReplyRepository.java
@@ -1,0 +1,24 @@
+package com.salayo.locallifebackend.domain.review.repository;
+
+import com.salayo.locallifebackend.domain.review.entity.Review;
+import com.salayo.locallifebackend.domain.review.entity.ReviewReply;
+import com.salayo.locallifebackend.domain.review.enums.ReviewStatus;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ReviewReplyRepository extends JpaRepository<ReviewReply, Long> {
+
+	boolean existsByReviewAndStatus(Review review, ReviewStatus status);
+
+	Optional<ReviewReply> findByReviewAndStatus(Review review, ReviewStatus status);
+
+	@Modifying
+	@Query("UPDATE ReviewReply r SET r.status = com.salayo.locallifebackend.domain.review.enums.ReviewStatus.DELETED, r.deletedAt = CURRENT_TIMESTAMP WHERE r.review = :review")
+	void softDeleteByReview(@Param("review") Review review);
+
+}

--- a/src/main/java/com/salayo/locallifebackend/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/review/repository/ReviewRepository.java
@@ -16,24 +16,24 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
-	Optional<Review> findByIdAndStatus(Long reviewId, ReviewStatus status);
+	Optional<Review> findByIdAndReviewStatus(Long reviewId, ReviewStatus reviewStatus);
 
-	boolean existsByMemberAndProgramAndStatus(Member member, Program program, ReviewStatus status);
+	boolean existsByMemberAndProgramAndReviewStatus(Member member, Program program, ReviewStatus reviewStatus);
 
-	@Query("SELECT r FROM Review r WHERE r.member = :member AND r.status = :status ORDER BY r.createdAt DESC")
-	List<Review> findByMemberAndStatus(@Param("member") Member member, @Param("status") ReviewStatus status);
+	@Query("SELECT r FROM Review r WHERE r.member = :member AND r.reviewStatus = :reviewStatus ORDER BY r.createdAt DESC")
+	List<Review> findByMemberAndReviewStatus(@Param("member") Member member, @Param("reviewStatus") ReviewStatus reviewStatus);
 
-	@Query("SELECT r FROM Review r WHERE r.program = :program AND r.status = :status ORDER BY r.createdAt DESC")
-	List<Review> findByProgramAndStatus(@Param("program") Program program, @Param("status") ReviewStatus status);
+	@Query("SELECT r FROM Review r WHERE r.program = :program AND r.reviewStatus = :reviewStatus ORDER BY r.createdAt DESC")
+	List<Review> findByProgramAndReviewStatus(@Param("program") Program program, @Param("reviewStatus") ReviewStatus reviewStatus);
 
-	@Query("SELECT r FROM Review r WHERE r.status = :status ORDER BY r.createdAt DESC")
-	List<Review> findAllByStatus(@Param("status") ReviewStatus status);
+	@Query("SELECT r FROM Review r WHERE r.reviewStatus = :reviewStatus ORDER BY r.createdAt DESC")
+	List<Review> findAllByReviewStatus(@Param("reviewStatus") ReviewStatus reviewStatus);
 
-	@Query("SELECT r FROM Review r LEFT JOIN FETCH r.replies WHERE r.id = :reviewId AND r.status = :status")
-	Optional<Review> findByIdAndStatusWithReplies(@Param("reviewId") Long reviewId, @Param("status") ReviewStatus status);
+	@Query("SELECT r FROM Review r LEFT JOIN FETCH r.replies WHERE r.id = :reviewId AND r.reviewStatus = :reviewStatus")
+	Optional<Review> findByIdAndReviewStatusWithReplies(@Param("reviewId") Long reviewId, @Param("reviewStatus") ReviewStatus reviewStatus);
 
-	default Review findByIdAndStatusOrThrow(Long reviewId, ReviewStatus status) {
-		return findByIdAndStatus(reviewId, status)
+	default Review findByIdAndReviewStatusOrThrow(Long reviewId, ReviewStatus reviewStatus) {
+		return findByIdAndReviewStatus(reviewId, reviewStatus)
 			.orElseThrow(() -> new CustomException(ErrorCode.REVIEW_NOT_FOUND));
 	}
 }

--- a/src/main/java/com/salayo/locallifebackend/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/review/repository/ReviewRepository.java
@@ -3,7 +3,7 @@ package com.salayo.locallifebackend.domain.review.repository;
 import com.salayo.locallifebackend.domain.member.entity.Member;
 import com.salayo.locallifebackend.domain.program.entity.Program;
 import com.salayo.locallifebackend.domain.review.entity.Review;
-import com.salayo.locallifebackend.domain.review.enums.ReviewStatus;
+import com.salayo.locallifebackend.global.enums.DeletedStatus;
 import com.salayo.locallifebackend.global.error.exception.CustomException;
 import com.salayo.locallifebackend.global.error.ErrorCode;
 import java.util.List;
@@ -16,24 +16,25 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
-	Optional<Review> findByIdAndReviewStatus(Long reviewId, ReviewStatus reviewStatus);
+	Optional<Review> findByIdAndDeletedStatus(Long reviewId, DeletedStatus deletedStatus);
 
-	boolean existsByMemberAndProgramAndReviewStatus(Member member, Program program, ReviewStatus reviewStatus);
+	boolean existsByMemberAndProgramAndDeletedStatus(Member member, Program program, DeletedStatus deletedStatus);
 
-	@Query("SELECT r FROM Review r WHERE r.member = :member AND r.reviewStatus = :reviewStatus ORDER BY r.createdAt DESC")
-	List<Review> findByMemberAndReviewStatus(@Param("member") Member member, @Param("reviewStatus") ReviewStatus reviewStatus);
+	@Query("SELECT r FROM Review r WHERE r.member = :member AND r.deletedStatus = :deletedStatus ORDER BY r.createdAt DESC")
+	List<Review> findByMemberAndDeletedStatus(@Param("member") Member member, @Param("deletedStatus") DeletedStatus deletedStatus);
 
-	@Query("SELECT r FROM Review r WHERE r.program = :program AND r.reviewStatus = :reviewStatus ORDER BY r.createdAt DESC")
-	List<Review> findByProgramAndReviewStatus(@Param("program") Program program, @Param("reviewStatus") ReviewStatus reviewStatus);
+	@Query("SELECT r FROM Review r WHERE r.program = :program AND r.deletedStatus = :deletedStatus ORDER BY r.createdAt DESC")
+	List<Review> findByProgramAndDeletedStatus(@Param("program") Program program, @Param("deletedStatus") DeletedStatus deletedStatus);
 
-	@Query("SELECT r FROM Review r WHERE r.reviewStatus = :reviewStatus ORDER BY r.createdAt DESC")
-	List<Review> findAllByReviewStatus(@Param("reviewStatus") ReviewStatus reviewStatus);
+	@Query("SELECT r FROM Review r WHERE r.deletedStatus = :deletedStatus ORDER BY r.createdAt DESC")
+	List<Review> findAllByDeletedStatus(@Param("deletedStatus") DeletedStatus deletedStatus);
 
-	@Query("SELECT r FROM Review r LEFT JOIN FETCH r.replies WHERE r.id = :reviewId AND r.reviewStatus = :reviewStatus")
-	Optional<Review> findByIdAndReviewStatusWithReplies(@Param("reviewId") Long reviewId, @Param("reviewStatus") ReviewStatus reviewStatus);
+	@Query("SELECT r FROM Review r LEFT JOIN FETCH r.replies WHERE r.id = :reviewId AND r.deletedStatus = :deletedStatus")
+	Optional<Review> findByIdAndDeletedStatusWithReplies(@Param("reviewId") Long reviewId,
+		@Param("deletedStatus") DeletedStatus deletedStatus);
 
-	default Review findByIdAndReviewStatusOrThrow(Long reviewId, ReviewStatus reviewStatus) {
-		return findByIdAndReviewStatus(reviewId, reviewStatus)
+	default Review findByIdAndDeletedStatusOrThrow(Long reviewId, DeletedStatus deletedStatus) {
+		return findByIdAndDeletedStatus(reviewId, deletedStatus)
 			.orElseThrow(() -> new CustomException(ErrorCode.REVIEW_NOT_FOUND));
 	}
 }

--- a/src/main/java/com/salayo/locallifebackend/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/review/repository/ReviewRepository.java
@@ -6,9 +6,8 @@ import com.salayo.locallifebackend.domain.review.entity.Review;
 import com.salayo.locallifebackend.domain.review.enums.ReviewStatus;
 import com.salayo.locallifebackend.global.error.exception.CustomException;
 import com.salayo.locallifebackend.global.error.ErrorCode;
+import java.util.List;
 import java.util.Optional;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -22,13 +21,13 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 	boolean existsByMemberAndProgramAndStatus(Member member, Program program, ReviewStatus status);
 
 	@Query("SELECT r FROM Review r WHERE r.member = :member AND r.status = :status ORDER BY r.createdAt DESC")
-	Page<Review> findByMemberAndStatus(@Param("member") Member member, @Param("status") ReviewStatus status, Pageable pageable);
+	List<Review> findByMemberAndStatus(@Param("member") Member member, @Param("status") ReviewStatus status);
 
 	@Query("SELECT r FROM Review r WHERE r.program = :program AND r.status = :status ORDER BY r.createdAt DESC")
-	Page<Review> findByProgramAndStatus(@Param("program") Program program, @Param("status") ReviewStatus status, Pageable pageable);
+	List<Review> findByProgramAndStatus(@Param("program") Program program, @Param("status") ReviewStatus status);
 
 	@Query("SELECT r FROM Review r WHERE r.status = :status ORDER BY r.createdAt DESC")
-	Page<Review> findAllByStatus(@Param("status") ReviewStatus status, Pageable pageable);
+	List<Review> findAllByStatus(@Param("status") ReviewStatus status);
 
 	@Query("SELECT r FROM Review r LEFT JOIN FETCH r.replies WHERE r.id = :reviewId AND r.status = :status")
 	Optional<Review> findByIdAndStatusWithReplies(@Param("reviewId") Long reviewId, @Param("status") ReviewStatus status);

--- a/src/main/java/com/salayo/locallifebackend/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/review/repository/ReviewRepository.java
@@ -1,0 +1,40 @@
+package com.salayo.locallifebackend.domain.review.repository;
+
+import com.salayo.locallifebackend.domain.member.entity.Member;
+import com.salayo.locallifebackend.domain.program.entity.Program;
+import com.salayo.locallifebackend.domain.review.entity.Review;
+import com.salayo.locallifebackend.domain.review.enums.ReviewStatus;
+import com.salayo.locallifebackend.global.error.exception.CustomException;
+import com.salayo.locallifebackend.global.error.ErrorCode;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+
+	Optional<Review> findByIdAndStatus(Long reviewId, ReviewStatus status);
+
+	boolean existsByMemberAndProgramAndStatus(Member member, Program program, ReviewStatus status);
+
+	@Query("SELECT r FROM Review r WHERE r.member = :member AND r.status = :status ORDER BY r.createdAt DESC")
+	Page<Review> findByMemberAndStatus(@Param("member") Member member, @Param("status") ReviewStatus status, Pageable pageable);
+
+	@Query("SELECT r FROM Review r WHERE r.program = :program AND r.status = :status ORDER BY r.createdAt DESC")
+	Page<Review> findByProgramAndStatus(@Param("program") Program program, @Param("status") ReviewStatus status, Pageable pageable);
+
+	@Query("SELECT r FROM Review r WHERE r.status = :status ORDER BY r.createdAt DESC")
+	Page<Review> findAllByStatus(@Param("status") ReviewStatus status, Pageable pageable);
+
+	@Query("SELECT r FROM Review r LEFT JOIN FETCH r.replies WHERE r.id = :reviewId AND r.status = :status")
+	Optional<Review> findByIdAndStatusWithReplies(@Param("reviewId") Long reviewId, @Param("status") ReviewStatus status);
+
+	default Review findByIdAndStatusOrThrow(Long reviewId, ReviewStatus status) {
+		return findByIdAndStatus(reviewId, status)
+			.orElseThrow(() -> new CustomException(ErrorCode.REVIEW_NOT_FOUND));
+	}
+}

--- a/src/main/java/com/salayo/locallifebackend/domain/review/service/ReviewCacheService.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/review/service/ReviewCacheService.java
@@ -1,0 +1,61 @@
+package com.salayo.locallifebackend.domain.review.service;
+
+import com.salayo.locallifebackend.global.util.CacheKeyPrefix;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ReviewCacheService {
+
+	@Qualifier("reviewRedisTemplate")
+	private final RedisTemplate<String, String> redisTemplate;
+
+	/**
+	 * 프로그램 리뷰 캐시 무효화 단일 키 삭제 방식
+	 */
+	public void invalidateReviewCache(Long programId) {
+		String cacheKey = CacheKeyPrefix.REVIEW_PROGRAM + programId;
+		redisTemplate.delete(cacheKey);
+		log.info("리뷰 캐시 무효화 - key: {}", cacheKey);
+	}
+
+	/**
+	 * 프로그램 리뷰 캐시 무효화 (패턴 매칭) 페이지네이션, 정렬 옵션 등 여러 캐시 키가 있을 경우 사용
+	 * <p>
+	 * 주의: keys() 명령어는 프로덕션에서 성능 이슈가 있을 수 있음 대안: SCAN 명령어 사용 또는 캐시 키 목록 별도 관리
+	 */
+	public void invalidateReviewCacheByPattern(Long programId) {
+		String pattern = CacheKeyPrefix.REVIEW_PROGRAM + programId + "*";
+		Set<String> keys = redisTemplate.keys(pattern);
+
+		if (keys != null && !keys.isEmpty()) {
+			redisTemplate.delete(keys);
+			log.info("리뷰 캐시 무효화 (패턴 매칭) - pattern: {}, count: {}", pattern, keys.size());
+		} else {
+			log.debug("리뷰 캐시 무효화 (패턴 매칭) - 삭제할 키 없음 - pattern: {}", pattern);
+		}
+	}
+
+	/**
+	 * 리뷰 캐시 조회
+	 */
+	public String getReviewCache(Long programId) {
+		String cacheKey = CacheKeyPrefix.REVIEW_PROGRAM + programId;
+		return redisTemplate.opsForValue().get(cacheKey);
+	}
+
+	/**
+	 * 리뷰 캐시 저장
+	 */
+	public void setReviewCache(Long programId, String value, long ttlMinutes) {
+		String cacheKey = CacheKeyPrefix.REVIEW_PROGRAM + programId;
+		redisTemplate.opsForValue().set(cacheKey, value, ttlMinutes, java.util.concurrent.TimeUnit.MINUTES);
+		log.info("리뷰 캐시 저장 - key: {}, ttl: {}분", cacheKey, ttlMinutes);
+	}
+}

--- a/src/main/java/com/salayo/locallifebackend/domain/review/service/ReviewCacheService.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/review/service/ReviewCacheService.java
@@ -2,7 +2,6 @@ package com.salayo.locallifebackend.domain.review.service;
 
 import com.salayo.locallifebackend.global.util.CacheKeyPrefix;
 import java.util.Set;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -10,23 +9,20 @@ import org.springframework.stereotype.Service;
 
 @Slf4j
 @Service
-@RequiredArgsConstructor
 public class ReviewCacheService {
 
-	@Qualifier("reviewRedisTemplate")
 	private final RedisTemplate<String, String> redisTemplate;
 
-	// 프로그램 리뷰 캐시 무효화 단일 키 삭제 방식
-	public void invalidateReviewCache(Long programId) {
-		String cacheKey = CacheKeyPrefix.REVIEW_PROGRAM + programId;
-		redisTemplate.delete(cacheKey);
-		log.info("리뷰 캐시 무효화 - key: {}", cacheKey);
+	public ReviewCacheService(@Qualifier("reviewRedisTemplate") RedisTemplate<String, String> redisTemplate) {
+		this.redisTemplate = redisTemplate;
 	}
 
 	/**
-	 * 프로그램 리뷰 캐시 무효화 (패턴 매칭) 페이지네이션, 정렬 옵션 등 여러 캐시 키가 있을 경우 사용
+	 * 프로그램 리뷰 캐시 무효화 (패턴 매칭)
+	 * 페이지네이션, 정렬 옵션 등 여러 캐시 키가 있을 경우 사용
 	 * <p>
-	 * 주의: keys() 명령어는 프로덕션에서 성능 이슈가 있을 수 있음 대안: SCAN 명령어 사용 또는 캐시 키 목록 별도 관리
+	 * 주의: keys() 명령어는 프로덕션에서 성능 이슈가 있을 수 있음
+	 * 대안: SCAN 명령어 사용 또는 캐시 키 목록 별도 관리
 	 */
 	public void invalidateReviewCacheByPattern(Long programId) {
 		String pattern = CacheKeyPrefix.REVIEW_PROGRAM + programId + "*";

--- a/src/main/java/com/salayo/locallifebackend/domain/review/service/ReviewCacheService.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/review/service/ReviewCacheService.java
@@ -16,9 +16,7 @@ public class ReviewCacheService {
 	@Qualifier("reviewRedisTemplate")
 	private final RedisTemplate<String, String> redisTemplate;
 
-	/**
-	 * 프로그램 리뷰 캐시 무효화 단일 키 삭제 방식
-	 */
+	// 프로그램 리뷰 캐시 무효화 단일 키 삭제 방식
 	public void invalidateReviewCache(Long programId) {
 		String cacheKey = CacheKeyPrefix.REVIEW_PROGRAM + programId;
 		redisTemplate.delete(cacheKey);
@@ -42,17 +40,13 @@ public class ReviewCacheService {
 		}
 	}
 
-	/**
-	 * 리뷰 캐시 조회
-	 */
+	// 리뷰 캐시 조회
 	public String getReviewCache(Long programId) {
 		String cacheKey = CacheKeyPrefix.REVIEW_PROGRAM + programId;
 		return redisTemplate.opsForValue().get(cacheKey);
 	}
 
-	/**
-	 * 리뷰 캐시 저장
-	 */
+	// 리뷰 캐시 저장
 	public void setReviewCache(Long programId, String value, long ttlMinutes) {
 		String cacheKey = CacheKeyPrefix.REVIEW_PROGRAM + programId;
 		redisTemplate.opsForValue().set(cacheKey, value, ttlMinutes, java.util.concurrent.TimeUnit.MINUTES);

--- a/src/main/java/com/salayo/locallifebackend/domain/review/service/ReviewReplyService.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/review/service/ReviewReplyService.java
@@ -36,8 +36,8 @@ public class ReviewReplyService {
 	public ReviewReplyResponseDto createReviewReply(Long reviewId, ReviewReplyRequestDto requestDto, Member creator) {
 		log.info("리뷰 답글 작성 시작 - reviewId: {}, creatorId: {}", reviewId, creator.getId());
 
-		// 글자수 제한 검증
-		validateContentLength(requestDto.getContent());
+		// 글자수 제한 검증 - DTO @Valid로 이미 검증됨
+		// validateContentLength(requestDto.getContent());
 
 		// 리뷰 존재 확인
 		Review review = reviewRepository.findByIdAndStatusOrThrow(reviewId, ReviewStatus.DISPLAYED);
@@ -72,15 +72,6 @@ public class ReviewReplyService {
 		}
 	}
 
-	private void validateContentLength(String content) {
-		if (content == null || content.trim().isEmpty()) {
-			throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
-		}
-
-		if (content.length() > 500) {
-			throw new CustomException(ErrorCode.REVIEW_CONTENT_TOO_LONG);
-		}
-	}
 
 	private void invalidateReviewCache(Long programId) {
 		String cacheKey = REVIEW_CACHE_KEY + programId;

--- a/src/main/java/com/salayo/locallifebackend/domain/review/service/ReviewReplyService.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/review/service/ReviewReplyService.java
@@ -40,13 +40,13 @@ public class ReviewReplyService {
 		// validateContentLength(requestDto.getContent());
 
 		// 리뷰 존재 확인
-		Review review = reviewRepository.findByIdAndStatusOrThrow(reviewId, ReviewStatus.DISPLAYED);
+		Review review = reviewRepository.findByIdAndReviewStatusOrThrow(reviewId, ReviewStatus.DISPLAYED);
 
 		// 프로그램 소유권 확인
 		validateProgramOwnership(review, creator);
 
 		// 답글 중복 체크
-		if (reviewReplyRepository.existsByReviewAndStatus(review, ReviewStatus.DISPLAYED)) {
+		if (reviewReplyRepository.existsByReviewAndReviewStatus(review, ReviewStatus.DISPLAYED)) {
 			throw new CustomException(ErrorCode.DUPLICATE_REVIEW_REPLY);
 		}
 

--- a/src/main/java/com/salayo/locallifebackend/domain/review/service/ReviewReplyService.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/review/service/ReviewReplyService.java
@@ -5,13 +5,11 @@ import com.salayo.locallifebackend.domain.review.dto.ReviewReplyRequestDto;
 import com.salayo.locallifebackend.domain.review.dto.ReviewReplyResponseDto;
 import com.salayo.locallifebackend.domain.review.entity.Review;
 import com.salayo.locallifebackend.domain.review.entity.ReviewReply;
-import com.salayo.locallifebackend.domain.review.enums.ReviewStatus;
+import com.salayo.locallifebackend.global.enums.DeletedStatus;
 import com.salayo.locallifebackend.domain.review.repository.ReviewReplyRepository;
 import com.salayo.locallifebackend.domain.review.repository.ReviewRepository;
 import com.salayo.locallifebackend.global.error.exception.CustomException;
 import com.salayo.locallifebackend.global.error.ErrorCode;
-import com.salayo.locallifebackend.global.util.CacheKeyPrefix;
-import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -40,13 +38,13 @@ public class ReviewReplyService {
 		// validateContentLength(requestDto.getContent());
 
 		// 리뷰 존재 확인
-		Review review = reviewRepository.findByIdAndReviewStatusOrThrow(reviewId, ReviewStatus.DISPLAYED);
+		Review review = reviewRepository.findByIdAndDeletedStatusOrThrow(reviewId, DeletedStatus.DISPLAYED);
 
 		// 프로그램 소유권 확인
 		validateProgramOwnership(review, creator);
 
 		// 답글 중복 체크
-		if (reviewReplyRepository.existsByReviewAndReviewStatus(review, ReviewStatus.DISPLAYED)) {
+		if (reviewReplyRepository.existsByReviewAndDeletedStatus(review, DeletedStatus.DISPLAYED)) {
 			throw new CustomException(ErrorCode.DUPLICATE_REVIEW_REPLY);
 		}
 

--- a/src/main/java/com/salayo/locallifebackend/domain/review/service/ReviewReplyService.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/review/service/ReviewReplyService.java
@@ -1,0 +1,89 @@
+package com.salayo.locallifebackend.domain.review.service;
+
+import com.salayo.locallifebackend.domain.member.entity.Member;
+import com.salayo.locallifebackend.domain.review.dto.ReviewReplyRequestDto;
+import com.salayo.locallifebackend.domain.review.dto.ReviewReplyResponseDto;
+import com.salayo.locallifebackend.domain.review.entity.Review;
+import com.salayo.locallifebackend.domain.review.entity.ReviewReply;
+import com.salayo.locallifebackend.domain.review.enums.ReviewStatus;
+import com.salayo.locallifebackend.domain.review.repository.ReviewReplyRepository;
+import com.salayo.locallifebackend.domain.review.repository.ReviewRepository;
+import com.salayo.locallifebackend.global.error.exception.CustomException;
+import com.salayo.locallifebackend.global.error.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+public class ReviewReplyService {
+
+	private final ReviewRepository reviewRepository;
+	private final ReviewReplyRepository reviewReplyRepository;
+	private final RedisTemplate<String, Object> redisTemplate;
+
+	private static final String REVIEW_CACHE_KEY = "review:program:";
+
+	public ReviewReplyService(ReviewRepository reviewRepository, ReviewReplyRepository reviewReplyRepository,
+		RedisTemplate<String, Object> redisTemplate) {
+		this.reviewRepository = reviewRepository;
+		this.reviewReplyRepository = reviewReplyRepository;
+		this.redisTemplate = redisTemplate;
+	}
+
+	@Transactional
+	public ReviewReplyResponseDto createReviewReply(Long reviewId, ReviewReplyRequestDto requestDto, Member creator) {
+		log.info("리뷰 답글 작성 시작 - reviewId: {}, creatorId: {}", reviewId, creator.getId());
+
+		// 글자수 제한 검증
+		validateContentLength(requestDto.getContent());
+
+		// 리뷰 존재 확인
+		Review review = reviewRepository.findByIdAndStatusOrThrow(reviewId, ReviewStatus.DISPLAYED);
+
+		// 프로그램 소유권 확인
+		validateProgramOwnership(review, creator);
+
+		// 답글 중복 체크
+		if (reviewReplyRepository.existsByReviewAndStatus(review, ReviewStatus.DISPLAYED)) {
+			throw new CustomException(ErrorCode.DUPLICATE_REVIEW_REPLY);
+		}
+
+		ReviewReply reviewReply = ReviewReply.builder()
+			.review(review)
+			.member(creator)
+			.content(requestDto.getContent())
+			.build();
+
+		ReviewReply savedReply = reviewReplyRepository.save(reviewReply);
+
+		// 캐시 무효화
+		invalidateReviewCache(review.getProgram().getId());
+
+		return new ReviewReplyResponseDto(savedReply);
+	}
+
+	private void validateProgramOwnership(Review review, Member creator) {
+		// TODO: 로컬 크리에이터가 해당 프로그램의 소유자인지 확인
+		// Program의 creator와 현재 사용자가 일치하는지 확인
+		if (!review.getProgram().getMember().getId().equals(creator.getId())) {
+			throw new CustomException(ErrorCode.FORBIDDEN_ACCESS);
+		}
+	}
+
+	private void validateContentLength(String content) {
+		if (content == null || content.trim().isEmpty()) {
+			throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
+		}
+
+		if (content.length() > 500) {
+			throw new CustomException(ErrorCode.REVIEW_CONTENT_TOO_LONG);
+		}
+	}
+
+	private void invalidateReviewCache(Long programId) {
+		String cacheKey = REVIEW_CACHE_KEY + programId;
+		redisTemplate.delete(cacheKey);
+	}
+}

--- a/src/main/java/com/salayo/locallifebackend/domain/review/service/ReviewReplyService.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/review/service/ReviewReplyService.java
@@ -11,6 +11,7 @@ import com.salayo.locallifebackend.domain.review.repository.ReviewRepository;
 import com.salayo.locallifebackend.global.error.exception.CustomException;
 import com.salayo.locallifebackend.global.error.ErrorCode;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,12 +22,12 @@ public class ReviewReplyService {
 
 	private final ReviewRepository reviewRepository;
 	private final ReviewReplyRepository reviewReplyRepository;
-	private final RedisTemplate<String, Object> redisTemplate;
+	private final RedisTemplate<String, String> redisTemplate;
 
 	private static final String REVIEW_CACHE_KEY = "review:program:";
 
 	public ReviewReplyService(ReviewRepository reviewRepository, ReviewReplyRepository reviewReplyRepository,
-		RedisTemplate<String, Object> redisTemplate) {
+		@Qualifier("reviewRedisTemplate") RedisTemplate<String, String> redisTemplate) {
 		this.reviewRepository = reviewRepository;
 		this.reviewReplyRepository = reviewReplyRepository;
 		this.redisTemplate = redisTemplate;

--- a/src/main/java/com/salayo/locallifebackend/domain/review/service/ReviewService.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/review/service/ReviewService.java
@@ -8,7 +8,7 @@ import com.salayo.locallifebackend.domain.reservation.repository.ReservationRepo
 import com.salayo.locallifebackend.domain.review.dto.ReviewRequestDto;
 import com.salayo.locallifebackend.domain.review.dto.ReviewResponseDto;
 import com.salayo.locallifebackend.domain.review.entity.Review;
-import com.salayo.locallifebackend.domain.review.enums.ReviewStatus;
+import com.salayo.locallifebackend.global.enums.DeletedStatus;
 import com.salayo.locallifebackend.domain.review.repository.ReviewReplyRepository;
 import com.salayo.locallifebackend.domain.review.repository.ReviewRepository;
 import com.salayo.locallifebackend.global.error.exception.CustomException;
@@ -64,7 +64,7 @@ public class ReviewService {
 		// validateContentLength(requestDto.getContent());
 
 		// 중복 리뷰 체크
-		if (reviewRepository.existsByMemberAndProgramAndReviewStatus(member, program, ReviewStatus.DISPLAYED)) {
+		if (reviewRepository.existsByMemberAndProgramAndDeletedStatus(member, program, DeletedStatus.DISPLAYED)) {
 			throw new CustomException(ErrorCode.DUPLICATE_REVIEW);
 		}
 
@@ -87,7 +87,7 @@ public class ReviewService {
 	public List<ReviewResponseDto> getMyReviews(Member member) {
 		log.info("내 리뷰 조회 - memberId: {}", member.getId());
 
-		List<Review> reviews = reviewRepository.findByMemberAndReviewStatus(member, ReviewStatus.DISPLAYED);
+		List<Review> reviews = reviewRepository.findByMemberAndDeletedStatus(member, DeletedStatus.DISPLAYED);
 
 		return reviews.stream()
 			.map(ReviewResponseDto::new)
@@ -101,7 +101,7 @@ public class ReviewService {
 		Program program = programRepository.findById(programId)
 			.orElseThrow(() -> new CustomException(ErrorCode.PROGRAM_NOT_FOUND));
 
-		List<Review> reviews = reviewRepository.findByProgramAndReviewStatus(program, ReviewStatus.DISPLAYED);
+		List<Review> reviews = reviewRepository.findByProgramAndDeletedStatus(program, DeletedStatus.DISPLAYED);
 
 		return reviews.stream()
 			.map(ReviewResponseDto::new)
@@ -112,7 +112,7 @@ public class ReviewService {
 	public List<ReviewResponseDto> getAllReviews() {
 		log.info("전체 리뷰 조회");
 
-		List<Review> reviews = reviewRepository.findAllByReviewStatus(ReviewStatus.DISPLAYED);
+		List<Review> reviews = reviewRepository.findAllByDeletedStatus(DeletedStatus.DISPLAYED);
 
 		return reviews.stream()
 			.map(ReviewResponseDto::new)
@@ -126,7 +126,7 @@ public class ReviewService {
 		// 글자수 제한 검증 - DTO @Valid로 이미 검증됨
 		// validateContentLength(requestDto.getContent());
 
-		Review review = reviewRepository.findByIdAndReviewStatusOrThrow(reviewId, ReviewStatus.DISPLAYED);
+		Review review = reviewRepository.findByIdAndDeletedStatusOrThrow(reviewId, DeletedStatus.DISPLAYED);
 
 		// 본인 확인
 		if (!review.getMember().getId().equals(member.getId())) {
@@ -134,7 +134,7 @@ public class ReviewService {
 		}
 
 		// 답글 존재 여부 확인
-		if (reviewReplyRepository.existsByReviewAndReviewStatus(review, ReviewStatus.DISPLAYED)) {
+		if (reviewReplyRepository.existsByReviewAndDeletedStatus(review, DeletedStatus.DISPLAYED)) {
 			throw new CustomException(ErrorCode.CANNOT_UPDATE_REVIEW_WITH_REPLY);
 		}
 
@@ -150,7 +150,7 @@ public class ReviewService {
 	public void deleteReview(Long reviewId, Member member) {
 		log.info("리뷰 삭제 - reviewId: {}, memberId: {}", reviewId, member.getId());
 
-		Review review = reviewRepository.findByIdAndReviewStatusOrThrow(reviewId, ReviewStatus.DISPLAYED);
+		Review review = reviewRepository.findByIdAndDeletedStatusOrThrow(reviewId, DeletedStatus.DISPLAYED);
 
 		// 본인 확인
 		if (!review.getMember().getId().equals(member.getId())) {

--- a/src/main/java/com/salayo/locallifebackend/domain/review/service/ReviewService.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/review/service/ReviewService.java
@@ -58,8 +58,9 @@ public class ReviewService {
 		// 체험 완료 확인
 		validateCompletedReservation(reservation, member);
 		
-		// 30일 이내 작성 가능 체크
-		validateReviewPeriod(reservation.getEndDate());
+		// 30일 이내 작성 가능 체크 - 임시로 현재 날짜 기준으로 체크
+		// TODO: ProgramSchedule의 종료일 또는 Program의 종료일 기준으로 변경 필요
+		validateReviewPeriod(LocalDate.now());
 
 		// 글자수 제한 검증
 		validateContentLength(requestDto.getContent());
@@ -173,16 +174,25 @@ public class ReviewService {
 			throw new CustomException(ErrorCode.UNAUTHORIZED);
 		}
 		
-		// TODO: 예약 상태가 완료인지 확인하는 로직 추가
-		// if (reservation.getStatus() != ReservationStatus.COMPLETED) {
+		// TODO: 예약 완료 상태 확인 로직 - 현재는 COMPLETED 상태로 가정
+		// 실제로는 아래 주석 해제하여 사용
+		// if (reservation.getReservationStatus() != ReservationStatus.COMPLETED) {
 		//     throw new CustomException(ErrorCode.REVIEW_NOT_ALLOWED);
 		// }
+		
+		// 임시로 모든 예약을 완료 상태로 가정
+		log.info("예약 상태 확인 - 임시로 COMPLETED 상태로 가정");
 	}
 
 	private void validateReviewPeriod(LocalDate experienceEndDate) {
-		if (experienceEndDate.plusDays(30).isBefore(LocalDate.now())) {
-			throw new CustomException(ErrorCode.REVIEW_PERIOD_EXPIRED);
-		}
+		// TODO: 실제 체험 종료일 기준으로 변경 필요
+		// 현재는 오늘 날짜 기준으로 30일 이내 항상 통과하도록 설정
+		log.info("리뷰 작성 기간 확인 - 임시로 항상 통과");
+		
+		// 원래 로직 (나중에 활성화)
+		// if (experienceEndDate.plusDays(30).isBefore(LocalDate.now())) {
+		//     throw new CustomException(ErrorCode.REVIEW_PERIOD_EXPIRED);
+		// }
 	}
 
 	private void validateContentLength(String content) {

--- a/src/main/java/com/salayo/locallifebackend/domain/review/service/ReviewService.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/review/service/ReviewService.java
@@ -15,8 +15,8 @@ import com.salayo.locallifebackend.global.error.exception.CustomException;
 import com.salayo.locallifebackend.global.error.ErrorCode;
 import java.time.LocalDate;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -85,33 +85,39 @@ public class ReviewService {
 	}
 
 	@Transactional(readOnly = true)
-	public Page<ReviewResponseDto> getMyReviews(Member member, Pageable pageable) {
+	public List<ReviewResponseDto> getMyReviews(Member member) {
 		log.info("내 리뷰 조회 - memberId: {}", member.getId());
 
-		Page<Review> reviews = reviewRepository.findByMemberAndStatus(member, ReviewStatus.DISPLAYED, pageable);
+		List<Review> reviews = reviewRepository.findByMemberAndStatus(member, ReviewStatus.DISPLAYED);
 
-		return reviews.map(ReviewResponseDto::new);
+		return reviews.stream()
+			.map(ReviewResponseDto::new)
+			.collect(Collectors.toList());
 	}
 
 	@Transactional(readOnly = true)
-	public Page<ReviewResponseDto> getProgramReviews(Long programId, Pageable pageable) {
+	public List<ReviewResponseDto> getProgramReviews(Long programId) {
 		log.info("프로그램 리뷰 조회 - programId: {}", programId);
 
 		Program program = programRepository.findById(programId)
 			.orElseThrow(() -> new CustomException(ErrorCode.PROGRAM_NOT_FOUND));
 
-		Page<Review> reviews = reviewRepository.findByProgramAndStatus(program, ReviewStatus.DISPLAYED, pageable);
+		List<Review> reviews = reviewRepository.findByProgramAndStatus(program, ReviewStatus.DISPLAYED);
 
-		return reviews.map(ReviewResponseDto::new);
+		return reviews.stream()
+			.map(ReviewResponseDto::new)
+			.collect(Collectors.toList());
 	}
 
 	@Transactional(readOnly = true)
-	public Page<ReviewResponseDto> getAllReviews(Pageable pageable) {
+	public List<ReviewResponseDto> getAllReviews() {
 		log.info("전체 리뷰 조회");
 
-		Page<Review> reviews = reviewRepository.findAllByStatus(ReviewStatus.DISPLAYED, pageable);
+		List<Review> reviews = reviewRepository.findAllByStatus(ReviewStatus.DISPLAYED);
 
-		return reviews.map(ReviewResponseDto::new);
+		return reviews.stream()
+			.map(ReviewResponseDto::new)
+			.collect(Collectors.toList());
 	}
 
 	@Transactional

--- a/src/main/java/com/salayo/locallifebackend/domain/review/service/ReviewService.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/review/service/ReviewService.java
@@ -17,8 +17,6 @@ import java.time.LocalDate;
 import lombok.extern.slf4j.Slf4j;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,19 +28,18 @@ public class ReviewService {
 	private final ReviewReplyRepository reviewReplyRepository;
 	private final ProgramRepository programRepository;
 	private final ReservationRepository reservationRepository;
-	private final RedisTemplate<String, String> redisTemplate;
+	private final ReviewCacheService reviewCacheService;
 
-	private static final String REVIEW_CACHE_KEY = "review:program:";
 	private static final long CACHE_TTL = 60; // 60분
 
 	public ReviewService(ReviewRepository reviewRepository, ReviewReplyRepository reviewReplyRepository,
 		ProgramRepository programRepository, ReservationRepository reservationRepository,
-		@Qualifier("reviewRedisTemplate") RedisTemplate<String, String> redisTemplate) {
+		ReviewCacheService reviewCacheService) {
 		this.reviewRepository = reviewRepository;
 		this.reviewReplyRepository = reviewReplyRepository;
 		this.programRepository = programRepository;
 		this.reservationRepository = reservationRepository;
-		this.redisTemplate = redisTemplate;
+		this.reviewCacheService = reviewCacheService;
 	}
 
 	@Transactional
@@ -52,13 +49,13 @@ public class ReviewService {
 		// 프로그램, 예약 조회
 		Program program = programRepository.findById(programId)
 			.orElseThrow(() -> new CustomException(ErrorCode.PROGRAM_NOT_FOUND));
-		
+
 		Reservation reservation = reservationRepository.findById(reservationId)
 			.orElseThrow(() -> new CustomException(ErrorCode.RESERVATION_NOT_FOUND));
 
 		// 체험 완료 확인
 		validateCompletedReservation(reservation, member);
-		
+
 		// 30일 이내 작성 가능 체크 - 임시로 현재 날짜 기준으로 체크
 		// TODO: ProgramSchedule의 종료일 또는 Program의 종료일 기준으로 변경 필요
 		validateReviewPeriod(LocalDate.now());
@@ -81,7 +78,7 @@ public class ReviewService {
 		Review savedReview = reviewRepository.save(review);
 
 		// 캐시 무효화
-		invalidateReviewCache(programId);
+		reviewCacheService.invalidateReviewCacheByPattern(programId);
 
 		return new ReviewResponseDto(savedReview);
 	}
@@ -144,7 +141,7 @@ public class ReviewService {
 		review.updateContent(requestDto.getContent());
 
 		// 캐시 무효화
-		invalidateReviewCache(review.getProgram().getId());
+		reviewCacheService.invalidateReviewCacheByPattern(review.getProgram().getId());
 
 		return new ReviewResponseDto(review);
 	}
@@ -167,20 +164,20 @@ public class ReviewService {
 		reviewReplyRepository.softDeleteByReview(review);
 
 		// 캐시 무효화
-		invalidateReviewCache(review.getProgram().getId());
+		reviewCacheService.invalidateReviewCacheByPattern(review.getProgram().getId());
 	}
 
 	private void validateCompletedReservation(Reservation reservation, Member member) {
 		if (!reservation.getMember().getId().equals(member.getId())) {
 			throw new CustomException(ErrorCode.UNAUTHORIZED);
 		}
-		
+
 		// TODO: 예약 완료 상태 확인 로직 - 현재는 COMPLETED 상태로 가정
 		// 실제로는 아래 주석 해제하여 사용
 		// if (reservation.getReservationStatus() != ReservationStatus.COMPLETED) {
 		//     throw new CustomException(ErrorCode.REVIEW_NOT_ALLOWED);
 		// }
-		
+
 		// 임시로 모든 예약을 완료 상태로 가정
 		log.info("예약 상태 확인 - 임시로 COMPLETED 상태로 가정");
 	}
@@ -189,16 +186,10 @@ public class ReviewService {
 		// TODO: 실제 체험 종료일 기준으로 변경 필요
 		// 현재는 오늘 날짜 기준으로 30일 이내 항상 통과하도록 설정
 		log.info("리뷰 작성 기간 확인 - 임시로 항상 통과");
-		
+
 		// 원래 로직 (나중에 활성화)
 		// if (experienceEndDate.plusDays(30).isBefore(LocalDate.now())) {
 		//     throw new CustomException(ErrorCode.REVIEW_PERIOD_EXPIRED);
 		// }
-	}
-
-
-	private void invalidateReviewCache(Long programId) {
-		String cacheKey = REVIEW_CACHE_KEY + programId;
-		redisTemplate.delete(cacheKey);
 	}
 }

--- a/src/main/java/com/salayo/locallifebackend/domain/review/service/ReviewService.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/review/service/ReviewService.java
@@ -66,7 +66,7 @@ public class ReviewService {
 		// validateContentLength(requestDto.getContent());
 
 		// 중복 리뷰 체크
-		if (reviewRepository.existsByMemberAndProgramAndStatus(member, program, ReviewStatus.DISPLAYED)) {
+		if (reviewRepository.existsByMemberAndProgramAndReviewStatus(member, program, ReviewStatus.DISPLAYED)) {
 			throw new CustomException(ErrorCode.DUPLICATE_REVIEW);
 		}
 
@@ -89,7 +89,7 @@ public class ReviewService {
 	public List<ReviewResponseDto> getMyReviews(Member member) {
 		log.info("내 리뷰 조회 - memberId: {}", member.getId());
 
-		List<Review> reviews = reviewRepository.findByMemberAndStatus(member, ReviewStatus.DISPLAYED);
+		List<Review> reviews = reviewRepository.findByMemberAndReviewStatus(member, ReviewStatus.DISPLAYED);
 
 		return reviews.stream()
 			.map(ReviewResponseDto::new)
@@ -103,7 +103,7 @@ public class ReviewService {
 		Program program = programRepository.findById(programId)
 			.orElseThrow(() -> new CustomException(ErrorCode.PROGRAM_NOT_FOUND));
 
-		List<Review> reviews = reviewRepository.findByProgramAndStatus(program, ReviewStatus.DISPLAYED);
+		List<Review> reviews = reviewRepository.findByProgramAndReviewStatus(program, ReviewStatus.DISPLAYED);
 
 		return reviews.stream()
 			.map(ReviewResponseDto::new)
@@ -114,7 +114,7 @@ public class ReviewService {
 	public List<ReviewResponseDto> getAllReviews() {
 		log.info("전체 리뷰 조회");
 
-		List<Review> reviews = reviewRepository.findAllByStatus(ReviewStatus.DISPLAYED);
+		List<Review> reviews = reviewRepository.findAllByReviewStatus(ReviewStatus.DISPLAYED);
 
 		return reviews.stream()
 			.map(ReviewResponseDto::new)
@@ -128,7 +128,7 @@ public class ReviewService {
 		// 글자수 제한 검증 - DTO @Valid로 이미 검증됨
 		// validateContentLength(requestDto.getContent());
 
-		Review review = reviewRepository.findByIdAndStatusOrThrow(reviewId, ReviewStatus.DISPLAYED);
+		Review review = reviewRepository.findByIdAndReviewStatusOrThrow(reviewId, ReviewStatus.DISPLAYED);
 
 		// 본인 확인
 		if (!review.getMember().getId().equals(member.getId())) {
@@ -136,7 +136,7 @@ public class ReviewService {
 		}
 
 		// 답글 존재 여부 확인
-		if (reviewReplyRepository.existsByReviewAndStatus(review, ReviewStatus.DISPLAYED)) {
+		if (reviewReplyRepository.existsByReviewAndReviewStatus(review, ReviewStatus.DISPLAYED)) {
 			throw new CustomException(ErrorCode.CANNOT_UPDATE_REVIEW_WITH_REPLY);
 		}
 
@@ -152,7 +152,7 @@ public class ReviewService {
 	public void deleteReview(Long reviewId, Member member) {
 		log.info("리뷰 삭제 - reviewId: {}, memberId: {}", reviewId, member.getId());
 
-		Review review = reviewRepository.findByIdAndStatusOrThrow(reviewId, ReviewStatus.DISPLAYED);
+		Review review = reviewRepository.findByIdAndReviewStatusOrThrow(reviewId, ReviewStatus.DISPLAYED);
 
 		// 본인 확인
 		if (!review.getMember().getId().equals(member.getId())) {

--- a/src/main/java/com/salayo/locallifebackend/domain/review/service/ReviewService.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/review/service/ReviewService.java
@@ -62,8 +62,8 @@ public class ReviewService {
 		// TODO: ProgramSchedule의 종료일 또는 Program의 종료일 기준으로 변경 필요
 		validateReviewPeriod(LocalDate.now());
 
-		// 글자수 제한 검증
-		validateContentLength(requestDto.getContent());
+		// 글자수 제한 검증 - DTO @Valid로 이미 검증됨
+		// validateContentLength(requestDto.getContent());
 
 		// 중복 리뷰 체크
 		if (reviewRepository.existsByMemberAndProgramAndStatus(member, program, ReviewStatus.DISPLAYED)) {
@@ -125,8 +125,8 @@ public class ReviewService {
 	public ReviewResponseDto updateReview(Long reviewId, ReviewRequestDto requestDto, Member member) {
 		log.info("리뷰 수정 - reviewId: {}, memberId: {}", reviewId, member.getId());
 
-		// 글자수 제한 검증
-		validateContentLength(requestDto.getContent());
+		// 글자수 제한 검증 - DTO @Valid로 이미 검증됨
+		// validateContentLength(requestDto.getContent());
 
 		Review review = reviewRepository.findByIdAndStatusOrThrow(reviewId, ReviewStatus.DISPLAYED);
 
@@ -195,15 +195,6 @@ public class ReviewService {
 		// }
 	}
 
-	private void validateContentLength(String content) {
-		if (content == null || content.trim().isEmpty()) {
-			throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
-		}
-
-		if (content.length() > 500) {
-			throw new CustomException(ErrorCode.REVIEW_CONTENT_TOO_LONG);
-		}
-	}
 
 	private void invalidateReviewCache(Long programId) {
 		String cacheKey = REVIEW_CACHE_KEY + programId;

--- a/src/main/java/com/salayo/locallifebackend/domain/review/service/ReviewService.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/review/service/ReviewService.java
@@ -50,11 +50,8 @@ public class ReviewService {
 		log.info("리뷰 작성 시작 - memberId: {}, programId: {}", member.getId(), programId);
 
 		// 프로그램, 예약 조회
-		Program program = programRepository.findById(programId)
-			.orElseThrow(() -> new CustomException(ErrorCode.PROGRAM_NOT_FOUND));
-
-		Reservation reservation = reservationRepository.findById(reservationId)
-			.orElseThrow(() -> new CustomException(ErrorCode.RESERVATION_NOT_FOUND));
+		Program program = programRepository.findByIdOrElseThrow(programId);
+		Reservation reservation = reservationRepository.findByIdOrElseThrow(reservationId);
 
 		// 체험 완료 확인
 		validateCompletedReservation(reservation, member);
@@ -101,8 +98,7 @@ public class ReviewService {
 	public List<ReviewResponseDto> getProgramReviews(Long programId) {
 		log.info("프로그램 리뷰 조회 - programId: {}", programId);
 
-		Program program = programRepository.findById(programId)
-			.orElseThrow(() -> new CustomException(ErrorCode.PROGRAM_NOT_FOUND));
+		Program program = programRepository.findByIdOrElseThrow(programId);
 
 		List<Review> reviews = reviewRepository.findByProgramAndDeletedStatus(program, DeletedStatus.DISPLAYED);
 

--- a/src/main/java/com/salayo/locallifebackend/domain/review/service/ReviewService.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/review/service/ReviewService.java
@@ -17,6 +17,7 @@ import java.time.LocalDate;
 import lombok.extern.slf4j.Slf4j;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,14 +30,14 @@ public class ReviewService {
 	private final ReviewReplyRepository reviewReplyRepository;
 	private final ProgramRepository programRepository;
 	private final ReservationRepository reservationRepository;
-	private final RedisTemplate<String, Object> redisTemplate;
+	private final RedisTemplate<String, String> redisTemplate;
 
 	private static final String REVIEW_CACHE_KEY = "review:program:";
 	private static final long CACHE_TTL = 60; // 60분
 
 	public ReviewService(ReviewRepository reviewRepository, ReviewReplyRepository reviewReplyRepository,
 		ProgramRepository programRepository, ReservationRepository reservationRepository,
-		RedisTemplate<String, Object> redisTemplate) {
+		@Qualifier("reviewRedisTemplate") RedisTemplate<String, String> redisTemplate) {
 		this.reviewRepository = reviewRepository;
 		this.reviewReplyRepository = reviewReplyRepository;
 		this.programRepository = programRepository;

--- a/src/main/java/com/salayo/locallifebackend/global/config/RedisConfig.java
+++ b/src/main/java/com/salayo/locallifebackend/global/config/RedisConfig.java
@@ -58,4 +58,12 @@ public class RedisConfig {
 		return redisTemplate;
 	}
 
+	@Bean(name = "reviewRedisTemplate")
+	public RedisTemplate<String, String> reviewRedisTemplate(RedisConnectionFactory redisConnectionFactory) {
+		RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+		redisTemplate.setConnectionFactory(redisConnectionFactory);
+		redisTemplate.setKeySerializer(new StringRedisSerializer());
+		redisTemplate.setValueSerializer(new StringRedisSerializer());
+		return redisTemplate;
+	}
 }

--- a/src/main/java/com/salayo/locallifebackend/global/error/ErrorCode.java
+++ b/src/main/java/com/salayo/locallifebackend/global/error/ErrorCode.java
@@ -30,6 +30,10 @@ public enum ErrorCode {
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "현재 비밀번호가 일치하지 않습니다."),
     MISSING_API_KEY(HttpStatus.BAD_REQUEST, "API KEY 값이 누락 되었습니다."),
     EMAIL_NOT_VERIFIED(HttpStatus.BAD_REQUEST, "이메일 인증이 완료되지 않았습니다."),
+    DUPLICATE_REVIEW(HttpStatus.BAD_REQUEST, "이미 리뷰를 작성하셨습니다."),
+    DUPLICATE_REVIEW_REPLY(HttpStatus.BAD_REQUEST, "이미 답글을 작성하셨습니다."),
+    REVIEW_CONTENT_TOO_LONG(HttpStatus.BAD_REQUEST, "리뷰는 최대 500자까지 작성 가능합니다."),
+    CANNOT_UPDATE_REVIEW_WITH_REPLY(HttpStatus.BAD_REQUEST, "답글이 달린 리뷰는 수정할 수 없습니다."),
 
     // 401 Unauthorized
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
@@ -44,6 +48,7 @@ public enum ErrorCode {
     CREATOR_NOT_APPROVED(HttpStatus.FORBIDDEN, "관리자 승인 후 로그인 가능합니다."),
     LOCAL_CREATOR_NOT_APPROVED(HttpStatus.FORBIDDEN, "로컬 크리에이터로 승인되지 않은 유저입니다."),
     RESERVATION_NOT_ALLOWED(HttpStatus.FORBIDDEN, "예약을 할 수 있는 권한이 없습니다."),
+    REVIEW_PERIOD_EXPIRED(HttpStatus.FORBIDDEN, "리뷰 작성 기한이 만료되었습니다."),
 
     // 404 NOT_FOUND
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 회원을 찾을 수 없습니다."),
@@ -53,6 +58,9 @@ public enum ErrorCode {
     LOCALCREATOR_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 회원을 찾을 수 없습니다."),
     NOT_FOUND_TEST_PROGRESS(HttpStatus.NOT_FOUND,"진행 중인 테스트가 없습니다."),
     PROGRAM_SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 프로그램 스케줄을 찾을 수 없습니다."),
+    PROGRAM_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 체험 프로그램을 찾을 수 없습니다."),
+    RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 예약을 찾을 수 없습니다."),
+    REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 리뷰를 찾을 수 없습니다."),
 
     // 408 REQUEST_TIMEOUT
     AI_TIMEOUT(HttpStatus.REQUEST_TIMEOUT, "AI 응답 시간이 초과되었습니다. 잠시 후 다시 시도해주세요."),

--- a/src/main/java/com/salayo/locallifebackend/global/util/CacheKeyPrefix.java
+++ b/src/main/java/com/salayo/locallifebackend/global/util/CacheKeyPrefix.java
@@ -1,0 +1,12 @@
+package com.salayo.locallifebackend.global.util;
+
+public final class CacheKeyPrefix {
+
+	// 리뷰 관련 캐시 키 프리픽스
+	public static final String REVIEW_PROGRAM = "review:program:"; // 실제 Redis 키 패턴 매칭용
+	public static final String PROGRAM_REVIEW_CACHE = "programReviews"; // Spring Cache @Cacheable/@CacheEvict value 이름
+
+	private CacheKeyPrefix() {
+		// 인스턴스화를 방지하기 위한 private 생성자
+	}
+}

--- a/src/main/java/com/salayo/locallifebackend/global/util/CacheKeyPrefix.java
+++ b/src/main/java/com/salayo/locallifebackend/global/util/CacheKeyPrefix.java
@@ -3,8 +3,7 @@ package com.salayo.locallifebackend.global.util;
 public final class CacheKeyPrefix {
 
 	// 리뷰 관련 캐시 키 프리픽스
-	public static final String REVIEW_PROGRAM = "review:program:"; // 실제 Redis 키 패턴 매칭용
-	public static final String PROGRAM_REVIEW_CACHE = "programReviews"; // Spring Cache @Cacheable/@CacheEvict value 이름
+	public static final String REVIEW_PROGRAM = "review:program:"; // 프로그램별 리뷰 캐시
 
 	private CacheKeyPrefix() {
 		// 인스턴스화를 방지하기 위한 private 생성자

--- a/src/main/resources/http/review.http
+++ b/src/main/resources/http/review.http
@@ -1,5 +1,5 @@
 ### 리뷰 작성
-POST http://localhost:8080/api/programs/1/reviews?reservationId=1
+POST http://localhost:8080/programs/1/reviews?reservationId=1
 Content-Type: application/json
 Authorization: Bearer {{authToken}}
 
@@ -8,7 +8,7 @@ Authorization: Bearer {{authToken}}
 }
 
 ### 리뷰 답글 작성
-POST http://localhost:8080/api/reviews/1/replies
+POST http://localhost:8080/reviews/1/replies
 Content-Type: application/json
 Authorization: Bearer {{authToken}}
 
@@ -17,14 +17,18 @@ Authorization: Bearer {{authToken}}
 }
 
 ### 내 리뷰 조회
-GET http://localhost:8080/api/mypage/reviews
+GET http://localhost:8080/mypage/reviews
 Authorization: Bearer {{authToken}}
 
 ### 프로그램 리뷰 조회
-GET http://localhost:8080/api/programs/1/reviews
+GET http://localhost:8080/programs/1/reviews
+
+### 관리자 전체 리뷰 조회
+GET http://localhost:8080/admin/reviews
+Authorization: Bearer {{authToken}}
 
 ### 리뷰 수정
-PUT http://localhost:8080/api/reviews/1
+PUT http://localhost:8080/reviews/1
 Content-Type: application/json
 Authorization: Bearer {{authToken}}
 
@@ -33,5 +37,5 @@ Authorization: Bearer {{authToken}}
 }
 
 ### 리뷰 삭제
-DELETE http://localhost:8080/api/reviews/1
+DELETE http://localhost:8080/reviews/1
 Authorization: Bearer {{authToken}}

--- a/src/main/resources/http/review.http
+++ b/src/main/resources/http/review.http
@@ -1,0 +1,37 @@
+### 리뷰 작성
+POST http://localhost:8080/api/programs/1/reviews?reservationId=1
+Content-Type: application/json
+Authorization: Bearer {{authToken}}
+
+{
+  "content": "정말 좋은 체험이었습니다!"
+}
+
+### 리뷰 답글 작성
+POST http://localhost:8080/api/reviews/1/replies
+Content-Type: application/json
+Authorization: Bearer {{authToken}}
+
+{
+  "content": "소중한 후기 감사합니다!"
+}
+
+### 내 리뷰 조회
+GET http://localhost:8080/api/mypage/reviews
+Authorization: Bearer {{authToken}}
+
+### 프로그램 리뷰 조회
+GET http://localhost:8080/api/programs/1/reviews
+
+### 리뷰 수정
+PUT http://localhost:8080/api/reviews/1
+Content-Type: application/json
+Authorization: Bearer {{authToken}}
+
+{
+  "content": "정말 좋은 체험이었습니다! 다시 참여하고 싶어요."
+}
+
+### 리뷰 삭제
+DELETE http://localhost:8080/api/reviews/1
+Authorization: Bearer {{authToken}}


### PR DESCRIPTION
## ☀️ 작업 목적

* 일반회원, 로컬 크리에이터, 관리자가 **리뷰 및 답글을 작성·조회·수정·삭제**할 수 있는 리뷰 관리 시스템을 구축했습니다.
* 체험 완료 검증, 1회 작성 제한, soft-delete, 답글 정책 등 **리뷰 신뢰성과 데이터 무결성 유지**를 위한 정책을 구현했습니다.
* UX를 고려한 에러처리와 본문/답글 **글자수 제한(500자)** 등 정책을 API에 반영했습니다.

---

## 📄 주요 작업 내역

#### 1. Entity/Enum/Repository 설계 #122 #129

* **Review Entity**

  * **Member**, **Program**, **Reservation**과 연관관계 (`@ManyToOne`)
  * soft-delete 및 상태 관리(`ReviewStatus`, `isDeleted`, `deletedAt`)
  * 수정 이력 및 '수정됨' 상태 판단
* **ReviewReply Entity**

  * `Review`와 양방향 연관, soft-delete 지원
* **ReviewStatus Enum**: `DISPLAYED`/`DELETED` 상태 정의
* **Repository**

  * **ReviewRepository**: 상태별 조회/중복 리뷰 체크/리스트 반환
  * **ReviewReplyRepository**: 답글 존재 여부/일괄 soft-delete

#### 2. DTO/Validation #122 #123 #124 #125 #128

* **요청 DTO**

  * `ReviewRequestDto`, `ReviewReplyRequestDto`: `@NotBlank`, `@Size(500)` 등 입력 검증 어노테이션 적용
* **응답 DTO**

  * `ReviewResponseDto`: `isModified`(수정됨) 플래그, 답글 목록 포함
  * `ReviewReplyResponseDto`: 크리에이터 정보 포함
* `@Valid`: 모든 컨트롤러에 적용, Service 중복 검증 제거

#### 3. 비즈니스 로직(Service) #122 #123 #124 #126 #127 #128

* **ReviewService**

  * 리뷰 작성(체험 완료/1회 제한/30일 내/글자수 제한)
  * 리뷰 수정(본인/답글 없는 경우만/수정 플래그)
  * 리뷰 삭제(soft-delete, 답글 동시 삭제)
  * 리뷰 전체 조회(마이페이지/프로그램별/전체, soft-delete 미노출, 수정됨 표시)
* **ReviewReplyService**

  * 답글 1회 작성, 소유권 검증, 수정/단독 삭제 불가 정책
  * 답글 등록 시 리뷰 상세 반환

#### 4. REST API/Controller #122 #123 #124 #125 #126 #127

* **ReviewController**

  * 리뷰 작성/조회/수정/삭제 CRUD 엔드포인트
  * 권한 체크(`@PreAuthorize`), `CommonResponseDto` 표준 응답
* **ReviewReplyController**

  * 답글 작성 전용 API, `LOCAL_CREATOR` 권한 체크

#### 5. 정책/Validation/에러처리 #122 #128

* 리뷰/답글 본문 500자 제한
* soft-delete 및 이력관리(DB 컬럼 추가)
* 중복 리뷰, 기간 제한, 소유권 체크 등 커스텀 예외 반환
* ErrorCode 추가 및 메시지 표준화

#### 6. 인프라/Redis #122 #128

* Redis 기반 리뷰 캐싱 설정, 빈 충돌 방지(`@Qualifier`)
* Review/ReviewReply의 RedisTemplate 명시적 주입

#### 7. 테스트 및 기타 #122 #125 #130

* review\.http: API 테스트 샘플 추가
* `isModified`, `experienceEndDate` 필드 오류 수정 및 엔티티 네이밍 통일

---

## 🛠️ 추가 수정 작업 (추가 구현 예정/미구현 이슈)

* **Swagger 문서화/명세화**

  * 엔드포인트/요청·응답 명확히 문서화 필요 (현재 미완)
* **리뷰 필터링/정렬/검색/페이징**

  * 카테고리, 태그, 닉네임/본문 검색, 최신순/인기순 정렬 및 페이지네이션(#132 등) 미구현
  * `ProgramGroup` 기반 시즌제 리뷰 누적 관리(쿼리/테이블 구조) 필요
* **"이런 점이 좋아요" 태그 기능**

  * 태그는 구조상 placeholder로만 반영, 실제 태깅 및 저장/검색은 미구현(#123)
* **리뷰/답글 단위 테스트 및 정책 예외처리**

  * JUnit, MockMvc 테스트 케이스 부족(#130)
  * 각종 정책 기반 예외 및 비정상 시나리오 케이스 추가 필요
* **예약/체험 완료/기간 제한 실제 검증 로직**

  * `ReservationStatus`/`ProgramSchedule` 종료일 기반 실제 검증은 임시로 주석/로직 대체 (#123)
* **성능 최적화/DB 인덱스/쿼리 개선**

  * Soft-delete, 정렬, 대량 데이터 대응 위한 쿼리 최적화 필요

---

## 📌 참고 및 TODO

* 리뷰 1회, 30일 작성 제한, soft-delete, 답글 1회 및 단독 삭제/수정 불가 등 정책 모두 Service 계층에서 일관 적용
* 물리 삭제 금지 및 데이터 신뢰성 확보 위해 `is_deleted`, `deleted_at`, `updated_at` 관리
* 추후 `Reservation`/`ProgramSchedule` 구조 개선시 리뷰 작성/기간 검증 로직 복구 필요
* 프론트엔드와 데이터 반환 구조(pagination/리뷰+답글/태그 포함) 연동 예정

---

## 🆕 2025.07.28 추가/수정 사항

1. 소프트 딜리트 Enum 통합 및 아키텍처 일원화 #122 #127 #129
* `ReviewStatus` → `DeletedStatus`로 통합, 모든 엔티티/필드명/컬럼/메서드에 적용 

* 프로젝트 전체의 soft-delete 패턴 일관성 확보 및 중복 Enum 제거

2. 캐싱 구조 리팩토링 및 통합 #122
* `CacheKeyPrefix` 클래스 도입: Redis/Spring 캐시 프리픽스 중앙화, 인스턴스화 방지 패턴 적용 

* `ReviewCacheService` 신설: invalidate/set/get 등 캐시 로직 서비스화, 중복/직접 접근 제거, 유지보수성↑

* `RedisTemplate` 빈 주입 오류 수정 및 `@Qualifier` 명시적 생성자 주입

3. `isModified()` 플래그 정확도 개선 #122 #126
* `isModified()` 버퍼 2초 적용: `createdAt=modifiedAt`(초기화/동기화 시) 및 1ms 차이 방지, 오탐지 감소

* `modifiedAt` `null` 체크, 진짜 수정 시에만 `true`로 반환

4. 삭제 시 영속성 컨텍스트 동기화/오류 방지 #122 #127
* `ReviewService.deleteReview()`에 `EntityManager.refresh() `적용

* `@Modifying(JPQL)` 쿼리 후 `review.getReplies()` 재접근 시 삭제 데이터 노출 문제 방지

5. Repository `findByIdOrElseThrow()` 메서드 일원화 #122 #125 #130
* 서비스 로직 내 `orElseThrow` 중복 제거, Repository `default` 메서드로 통일

* 코드 가독성 및 예외 관리 일관성 강화

--- 

**리뷰 및 피드백 환영합니다! 🤗**
