### PR TITLE
✨  feat : 체험 프로그램 삭제 API 구현, 체험 프로그램 등록 API 수정, ProgramStatus Enum 추가

### DIFF
--- a/src/main/java/com/salayo/locallifebackend/domain/program/controller/ProgramController.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/program/controller/ProgramController.java
@@ -23,8 +23,11 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -85,7 +88,7 @@ public class ProgramController {
 		summary = "체험 프로그램 조회",
 		description = "유저가 정렬 조건을 설정하여 체험 프로그램을 조회 할 수 있습니다."
 	)
-	@GetMapping(value = "/program/search")
+	@GetMapping(value = "/programs/search")
 	public ResponseEntity<CommonResponseDto<PaginationResponseDto<ProgramCreateResponseDto>>> searchProgram(
 		@ModelAttribute ProgramSearchRequestDto requestDto,
 		@AuthenticationPrincipal MemberDetails memberDetails) {
@@ -95,6 +98,26 @@ public class ProgramController {
 		PaginationResponseDto<ProgramCreateResponseDto> responsePage = programService.searchProgram(requestDto, memberId);
 
 		return ResponseEntity.ok(CommonResponseDto.success(SuccessCode.FETCH_SUCCESS, responsePage));
+	}
+
+	/**
+	 * 체험 프로그램 삭제 API
+	 */
+	@Operation(
+		summary = "체험 프로그램 삭제",
+		description = "로컬 크리에이터 유저가 체험 프로그램을 삭제 할 수 있습니다."
+	)
+	@PreAuthorize("hasRole('LOCAL_CREATOR')")
+	@PatchMapping("/programs/{programId}")
+	public ResponseEntity<CommonResponseDto<Long>> deleteProgram(
+		@PathVariable("programId") Long programId,
+		@AuthenticationPrincipal MemberDetails memberDetails) {
+
+		Long memberId = memberDetails.getMember().getId();
+
+		programService.deleteProgram(programId, memberId);
+
+		return ResponseEntity.ok(CommonResponseDto.success(SuccessCode.DELETE_SUCCESS, programId));
 	}
 
 }

--- a/src/main/java/com/salayo/locallifebackend/domain/program/entity/Program.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/program/entity/Program.java
@@ -168,5 +168,8 @@ public class Program extends BaseEntity {
 		programSchedule.connectToProgram(this);
 	}
 
+	public void updateStatus(DeletedStatus deletedStatus) {
+		this.deletedStatus = deletedStatus;
+	}
 
 }

--- a/src/main/java/com/salayo/locallifebackend/domain/program/enums/ProgramStatus.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/program/enums/ProgramStatus.java
@@ -1,7 +1,8 @@
 package com.salayo.locallifebackend.domain.program.enums;
 
 public enum ProgramStatus {
-	DRAFT , //작성 중
+	DRAFT, //작성 중
+	PENDING, //심사 대기 중
 	REGISTERED, //등록 완료
 	;
 }

--- a/src/main/java/com/salayo/locallifebackend/domain/program/service/ProgramService.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/program/service/ProgramService.java
@@ -344,19 +344,17 @@ public class ProgramService {
 			.map(ProgramSchedule::getId)
 			.toList();
 
-		List<Reservation> reservations = reservationRepository.findAllByProgramSchedule_IdIn(scheduleIds);
-
-		boolean hasCompletedReservation = reservations.stream()
-			.anyMatch(reservation -> reservation.getReservationStatus() == ReservationStatus.COMPLETED);
+		boolean hasCompletedReservation = reservationRepository.existsByProgramSchedule_IdInAndReservationStatus(
+			scheduleIds, ReservationStatus.COMPLETED);
 		if (hasCompletedReservation) {
 			throw new CustomException(ErrorCode.CANNOT_DELETE_COMPLETED_RESERVATION_EXISTS);
 		}
 
-		boolean hasActiveReservation = reservations.stream()
-			.anyMatch(reservation ->
-				reservation.getReservationStatus() != ReservationStatus.REJECTED &&
-					reservation.getReservationStatus() != ReservationStatus.CANCELED &&
-					reservation.getReservationStatus() != ReservationStatus.EXPIRED);
+		boolean hasActiveReservation = reservationRepository.existsByProgramSchedule_IdInAndReservationStatusNotIn(
+			scheduleIds, List.of(
+				ReservationStatus.REJECTED,
+				ReservationStatus.CANCELED,
+				ReservationStatus.EXPIRED));
 		if (hasActiveReservation) {
 			throw new CustomException(ErrorCode.CANNOT_DELETE_ACTIVE_RESERVATION_EXIST);
 		}

--- a/src/main/java/com/salayo/locallifebackend/domain/programschedule/entity/ProgramSchedule.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/programschedule/entity/ProgramSchedule.java
@@ -67,4 +67,9 @@ public class ProgramSchedule extends BaseEntity {
 	public void connectToProgram(Program program) {
 		this.program = program;
 	}
+
+	public void updateStatus(DeletedStatus deletedStatus, ProgramScheduleStatus programScheduleStatus) {
+		this.deletedStatus = deletedStatus;
+		this.programScheduleStatus = programScheduleStatus;
+	}
 }

--- a/src/main/java/com/salayo/locallifebackend/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/reservation/repository/ReservationRepository.java
@@ -2,6 +2,7 @@ package com.salayo.locallifebackend.domain.reservation.repository;
 
 
 import com.salayo.locallifebackend.domain.reservation.entity.Reservation;
+import com.salayo.locallifebackend.domain.reservation.enums.ReservationStatus;
 import com.salayo.locallifebackend.global.error.ErrorCode;
 import com.salayo.locallifebackend.global.error.exception.CustomException;
 import java.util.List;
@@ -15,5 +16,8 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
 		return findById(reservationId).orElseThrow(() -> new CustomException(ErrorCode.RESERVATION_NOT_FOUND));
 	}
 
-	List<Reservation> findAllByProgramSchedule_IdIn(List<Long> scheduleIds);
+	boolean existsByProgramSchedule_IdInAndReservationStatus(List<Long> scheduleIds, ReservationStatus completed);
+
+	boolean existsByProgramSchedule_IdInAndReservationStatusNotIn(List<Long> scheduleIds, List<ReservationStatus> excludedStatuses);
+
 }

--- a/src/main/java/com/salayo/locallifebackend/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/reservation/repository/ReservationRepository.java
@@ -1,9 +1,10 @@
 package com.salayo.locallifebackend.domain.reservation.repository;
 
-import com.salayo.locallifebackend.domain.program.entity.Program;
+
 import com.salayo.locallifebackend.domain.reservation.entity.Reservation;
 import com.salayo.locallifebackend.global.error.ErrorCode;
 import com.salayo.locallifebackend.global.error.exception.CustomException;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -14,4 +15,5 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
 		return findById(reservationId).orElseThrow(() -> new CustomException(ErrorCode.RESERVATION_NOT_FOUND));
 	}
 
+	List<Reservation> findAllByProgramSchedule_IdIn(List<Long> scheduleIds);
 }

--- a/src/main/java/com/salayo/locallifebackend/global/error/ErrorCode.java
+++ b/src/main/java/com/salayo/locallifebackend/global/error/ErrorCode.java
@@ -31,6 +31,10 @@ public enum ErrorCode {
     MISSING_API_KEY(HttpStatus.BAD_REQUEST, "API KEY 값이 누락 되었습니다."),
     EMAIL_NOT_VERIFIED(HttpStatus.BAD_REQUEST, "이메일 인증이 완료되지 않았습니다."),
     INVALID_SORT_TYPE(HttpStatus.BAD_REQUEST, "정렬 조건이 올바르지 않습니다."),
+    CANNOT_DELETE_BEFORE_START(HttpStatus.BAD_REQUEST, "시작일 7일 전에는 프로그램을 삭제할 수 없습니다."),
+    CANNOT_DELETE_COMPLETED_RESERVATION_EXISTS(HttpStatus.BAD_REQUEST, "체험 완료한 유저가 존재해 삭제할 수 없습니다."),
+    CANNOT_DELETE_ACTIVE_RESERVATION_EXIST(HttpStatus.BAD_REQUEST, "진행중인 예약이 있어 삭제할 수 없습니다."),
+    PROGRAM_DELETED(HttpStatus.BAD_REQUEST, "삭제된 체험 프로그램입니다."),
 
     // 401 Unauthorized
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),

--- a/src/main/resources/http/program.http
+++ b/src/main/resources/http/program.http
@@ -79,3 +79,7 @@ Authorization: Bearer {{accessToken}}
 &page=0
 &size=10
 
+### 체험 프로그램 삭제 API - (soft-delete)
+PATCH http://localhost:8080/programs/2
+Content-Type: application/json
+Authorization: Bearer {{accessToken}}

--- a/src/main/resources/http/program.http
+++ b/src/main/resources/http/program.http
@@ -80,6 +80,6 @@ Authorization: Bearer {{accessToken}}
 &size=10
 
 ### 체험 프로그램 삭제 API - (soft-delete)
-PATCH http://localhost:8080/programs/2
+PATCH http://localhost:8080/programs/3
 Content-Type: application/json
 Authorization: Bearer {{accessToken}}


### PR DESCRIPTION
🟪 체험 프로그램 삭제 기능 구현
  - 시작일 기준 7일 이내 삭제
  - 모든 예약이 거절, 취소, 만료 상태일 경우에만 삭제 가능
  - 체험 완료 상태의 예약이 존재하면 삭제 불가
  - 삭제 시, ProgramSchedule도 DELETE, INACTIVE 상태로 변경

🟪 체험 프로그램 등록 기능 수정
  - 등록 시, PENDING 상태로 변경

🟪 ProgramStatus Enum 추가
  - PENDEING Enum 추가