### PR TITLE
:sparkles: feat : 매거진 피드백(수정 요청) 등록 기능 구현

### DIFF
--- a/src/main/java/com/salayo/locallifebackend/domain/magazine/feedback/controller/MagazineFeedbackController.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/magazine/feedback/controller/MagazineFeedbackController.java
@@ -21,7 +21,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/magazines/{magazineId}/feedbacks")
+@RequestMapping("/localcreator/magazines/{magazineId}/feedbacks")
 @Tag(name = "Magazine Feedback | LocalCreator", description = "로컬 크리에이터 매거진 피드백 API")
 public class MagazineFeedbackController {
 

--- a/src/main/java/com/salayo/locallifebackend/domain/magazine/feedback/controller/MagazineFeedbackController.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/magazine/feedback/controller/MagazineFeedbackController.java
@@ -1,6 +1,7 @@
 package com.salayo.locallifebackend.domain.magazine.feedback.controller;
 
 import com.salayo.locallifebackend.domain.magazine.feedback.dto.MagazineFeedbackCreateRequestDto;
+import com.salayo.locallifebackend.domain.magazine.feedback.dto.MagazineFeedbackResponseDto;
 import com.salayo.locallifebackend.domain.magazine.feedback.service.MagazineFeedbackService;
 import com.salayo.locallifebackend.global.dto.CommonResponseDto;
 import com.salayo.locallifebackend.global.security.MemberDetails;
@@ -8,9 +9,11 @@ import com.salayo.locallifebackend.global.success.SuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -39,5 +42,18 @@ public class MagazineFeedbackController {
         magazineFeedbackService.createFeedback(magazineId, memberDetails.getMember().getId(), createRequestDto);
 
         return ResponseEntity.ok(CommonResponseDto.success(SuccessCode.CREATE_SUCCESS, null));
+    }
+
+    @Operation(summary = "내가 작성한 피드백 조회", description = "로컬 크리에이터가 본인의 인터뷰 매거진에 남긴 피드백 목록을 조회합니다.")
+    @PreAuthorize("hasRole('LOCAL_CREATOR')")
+    @GetMapping
+    public ResponseEntity<CommonResponseDto<List<MagazineFeedbackResponseDto>>> getMyFeedbacks(
+        @PathVariable Long magazineId,
+        @AuthenticationPrincipal MemberDetails memberDetails) {
+
+        List<MagazineFeedbackResponseDto> feedbacks = magazineFeedbackService
+            .getMyFeedbacks(magazineId, memberDetails.getMember().getId());
+
+        return ResponseEntity.ok(CommonResponseDto.success(SuccessCode.FETCH_SUCCESS, feedbacks));
     }
 }

--- a/src/main/java/com/salayo/locallifebackend/domain/magazine/feedback/controller/MagazineFeedbackController.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/magazine/feedback/controller/MagazineFeedbackController.java
@@ -1,0 +1,43 @@
+package com.salayo.locallifebackend.domain.magazine.feedback.controller;
+
+import com.salayo.locallifebackend.domain.magazine.feedback.dto.MagazineFeedbackCreateRequestDto;
+import com.salayo.locallifebackend.domain.magazine.feedback.service.MagazineFeedbackService;
+import com.salayo.locallifebackend.global.dto.CommonResponseDto;
+import com.salayo.locallifebackend.global.security.MemberDetails;
+import com.salayo.locallifebackend.global.success.SuccessCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/magazines/{magazineId}/feedbacks")
+@Tag(name = "Magazine Feedback | LocalCreator", description = "로컬 크리에이터 매거진 피드백 API")
+public class MagazineFeedbackController {
+
+    private final MagazineFeedbackService magazineFeedbackService;
+
+    public MagazineFeedbackController(MagazineFeedbackService magazineFeedbackService) {
+        this.magazineFeedbackService = magazineFeedbackService;
+    }
+
+    @Operation(summary = "매거진 피드백(수정 요청) 등록", description = "로컬 크리에이터가 본인의 인터뷰 매거진을 보고 피드백을 남깁니다. (최대 3회)")
+    @PreAuthorize("hasRole('LOCAL_CREATOR')")
+    @PostMapping
+    public ResponseEntity<CommonResponseDto<Void>> createFeedback(
+        @PathVariable Long magazineId,
+        @RequestBody @Valid MagazineFeedbackCreateRequestDto createRequestDto,
+        @AuthenticationPrincipal MemberDetails memberDetails) {
+
+        magazineFeedbackService.createFeedback(magazineId, memberDetails.getMember().getId(), createRequestDto);
+
+        return ResponseEntity.ok(CommonResponseDto.success(SuccessCode.CREATE_SUCCESS, null));
+    }
+}

--- a/src/main/java/com/salayo/locallifebackend/domain/magazine/feedback/dto/MagazineFeedbackCreateRequestDto.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/magazine/feedback/dto/MagazineFeedbackCreateRequestDto.java
@@ -1,6 +1,7 @@
 package com.salayo.locallifebackend.domain.magazine.feedback.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -8,6 +9,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class MagazineFeedbackCreateRequestDto {
 
+    @Size(max = 1000, message = "피드백 내용은 1000자 이내여야 합니다.")
     @NotBlank(message = "피드백 내용은 필수입니다.")
     private String content;
 

--- a/src/main/java/com/salayo/locallifebackend/domain/magazine/feedback/dto/MagazineFeedbackCreateRequestDto.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/magazine/feedback/dto/MagazineFeedbackCreateRequestDto.java
@@ -1,0 +1,14 @@
+package com.salayo.locallifebackend.domain.magazine.feedback.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MagazineFeedbackCreateRequestDto {
+
+    @NotBlank(message = "피드백 내용은 필수입니다.")
+    private String content;
+
+}

--- a/src/main/java/com/salayo/locallifebackend/domain/magazine/feedback/dto/MagazineFeedbackResponseDto.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/magazine/feedback/dto/MagazineFeedbackResponseDto.java
@@ -1,0 +1,24 @@
+package com.salayo.locallifebackend.domain.magazine.feedback.dto;
+
+import com.salayo.locallifebackend.domain.magazine.feedback.entity.MagazineFeedback;
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Getter
+public class MagazineFeedbackResponseDto {
+
+    private final Long id;
+    private final String content;
+    private final int revisionCount;
+    private final String creatorBusinessName;
+    private final LocalDateTime createdAt;
+
+    public MagazineFeedbackResponseDto(MagazineFeedback feedback) {
+        this.id = feedback.getId();
+        this.content = feedback.getContent();
+        this.revisionCount = feedback.getRevisionCount();
+        this.creatorBusinessName = feedback.getLocalCreator().getBusinessName();
+        this.createdAt = feedback.getCreatedAt();
+    }
+
+}

--- a/src/main/java/com/salayo/locallifebackend/domain/magazine/feedback/entity/MagazineFeedback.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/magazine/feedback/entity/MagazineFeedback.java
@@ -1,0 +1,56 @@
+package com.salayo.locallifebackend.domain.magazine.feedback.entity;
+
+import com.salayo.locallifebackend.domain.localcreator.entity.LocalCreator;
+import com.salayo.locallifebackend.domain.magazine.entity.Magazine;
+import com.salayo.locallifebackend.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "magazine_feedback")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MagazineFeedback extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "magazine_id", nullable = false)
+    private Magazine magazine;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "local_creator_id", nullable = false)
+    private LocalCreator localCreator;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Column(nullable = false)
+    private int revisionCount;
+
+    @Builder
+    public MagazineFeedback(Magazine magazine, LocalCreator localCreator, String content, int revisionCount) {
+        this.magazine = magazine;
+        this.localCreator = localCreator;
+        this.content = content;
+        this.revisionCount = revisionCount;
+    }
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
+
+}

--- a/src/main/java/com/salayo/locallifebackend/domain/magazine/feedback/repository/MagazineFeedbackRepository.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/magazine/feedback/repository/MagazineFeedbackRepository.java
@@ -1,0 +1,10 @@
+package com.salayo.locallifebackend.domain.magazine.feedback.repository;
+
+import com.salayo.locallifebackend.domain.magazine.feedback.entity.MagazineFeedback;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MagazineFeedbackRepository extends JpaRepository<MagazineFeedback, Long> {
+
+    List<MagazineFeedback> findByMagazineIdAndLocalCreatorId(Long magazineId, Long localCreatorId);
+}

--- a/src/main/java/com/salayo/locallifebackend/domain/magazine/feedback/service/MagazineFeedbackService.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/magazine/feedback/service/MagazineFeedbackService.java
@@ -37,6 +37,10 @@ public class MagazineFeedbackService {
         LocalCreator localCreator = localCreatorRepository.findByMemberId(memberId)
             .orElseThrow(() -> new CustomException(ErrorCode.LOCAL_CREATOR_NOT_FOUND));
 
+        if (!magazine.getLocalCreator().getId().equals(localCreator.getId())) {
+            throw new CustomException(ErrorCode.FORBIDDEN_ACCESS);
+        }
+
         int feedbackCount = magazineFeedbackRepository.findByMagazineIdAndLocalCreatorId(magazineId, localCreator.getId()).size();
 
         if (feedbackCount >= 3) {
@@ -57,6 +61,13 @@ public class MagazineFeedbackService {
     public List<MagazineFeedbackResponseDto> getMyFeedbacks(Long magazineId, Long memberId) {
         LocalCreator localCreator = localCreatorRepository.findByMemberId(memberId)
             .orElseThrow(() -> new CustomException(ErrorCode.LOCAL_CREATOR_NOT_FOUND));
+
+        Magazine magazine = magazineRepository.findById(magazineId)
+            .orElseThrow(() -> new CustomException(ErrorCode.MAGAZINE_NOT_FOUND));
+
+        if (!magazine.getLocalCreator().getId().equals(localCreator.getId())) {
+            throw new CustomException(ErrorCode.FORBIDDEN_ACCESS);
+        }
 
         return magazineFeedbackRepository.findByMagazineIdAndLocalCreatorId(magazineId, localCreator.getId())
             .stream()

--- a/src/main/java/com/salayo/locallifebackend/domain/magazine/feedback/service/MagazineFeedbackService.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/magazine/feedback/service/MagazineFeedbackService.java
@@ -1,0 +1,52 @@
+package com.salayo.locallifebackend.domain.magazine.feedback.service;
+
+import com.salayo.locallifebackend.domain.localcreator.entity.LocalCreator;
+import com.salayo.locallifebackend.domain.localcreator.repository.LocalCreatorRepository;
+import com.salayo.locallifebackend.domain.magazine.entity.Magazine;
+import com.salayo.locallifebackend.domain.magazine.feedback.dto.MagazineFeedbackCreateRequestDto;
+import com.salayo.locallifebackend.domain.magazine.feedback.entity.MagazineFeedback;
+import com.salayo.locallifebackend.domain.magazine.feedback.repository.MagazineFeedbackRepository;
+import com.salayo.locallifebackend.domain.magazine.repository.MagazineRepository;
+import com.salayo.locallifebackend.global.error.ErrorCode;
+import com.salayo.locallifebackend.global.error.exception.CustomException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class MagazineFeedbackService {
+
+    private final MagazineFeedbackRepository magazineFeedbackRepository;
+    private final MagazineRepository magazineRepository;
+    private final LocalCreatorRepository localCreatorRepository;
+
+    public MagazineFeedbackService(MagazineFeedbackRepository magazineFeedbackRepository, MagazineRepository magazineRepository,
+        LocalCreatorRepository localCreatorRepository) {
+        this.magazineFeedbackRepository = magazineFeedbackRepository;
+        this.magazineRepository = magazineRepository;
+        this.localCreatorRepository = localCreatorRepository;
+    }
+
+    @Transactional
+    public void createFeedback(Long magazineId, Long memberId, MagazineFeedbackCreateRequestDto createRequestDto) {
+        Magazine magazine = magazineRepository.findById(magazineId)
+            .orElseThrow(() -> new CustomException(ErrorCode.MAGAZINE_NOT_FOUND));
+
+        LocalCreator localCreator = localCreatorRepository.findByMemberId(memberId)
+            .orElseThrow(() -> new CustomException(ErrorCode.LOCAL_CREATOR_NOT_FOUND));
+
+        int feedbackCount = magazineFeedbackRepository.findByMagazineIdAndLocalCreatorId(magazineId, localCreator.getId()).size();
+
+        if (feedbackCount >= 3) {
+            throw new CustomException(ErrorCode.FEEDBACK_LIMIT_EXCEEDED);
+        }
+
+        MagazineFeedback magazineFeedback = MagazineFeedback.builder()
+            .magazine(magazine)
+            .localCreator(localCreator)
+            .content(createRequestDto.getContent())
+            .revisionCount(feedbackCount + 1)
+            .build();
+
+        magazineFeedbackRepository.save(magazineFeedback);
+    }
+}

--- a/src/main/java/com/salayo/locallifebackend/domain/magazine/feedback/service/MagazineFeedbackService.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/magazine/feedback/service/MagazineFeedbackService.java
@@ -4,11 +4,14 @@ import com.salayo.locallifebackend.domain.localcreator.entity.LocalCreator;
 import com.salayo.locallifebackend.domain.localcreator.repository.LocalCreatorRepository;
 import com.salayo.locallifebackend.domain.magazine.entity.Magazine;
 import com.salayo.locallifebackend.domain.magazine.feedback.dto.MagazineFeedbackCreateRequestDto;
+import com.salayo.locallifebackend.domain.magazine.feedback.dto.MagazineFeedbackResponseDto;
 import com.salayo.locallifebackend.domain.magazine.feedback.entity.MagazineFeedback;
 import com.salayo.locallifebackend.domain.magazine.feedback.repository.MagazineFeedbackRepository;
 import com.salayo.locallifebackend.domain.magazine.repository.MagazineRepository;
 import com.salayo.locallifebackend.global.error.ErrorCode;
 import com.salayo.locallifebackend.global.error.exception.CustomException;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -48,5 +51,16 @@ public class MagazineFeedbackService {
             .build();
 
         magazineFeedbackRepository.save(magazineFeedback);
+    }
+
+    @Transactional
+    public List<MagazineFeedbackResponseDto> getMyFeedbacks(Long magazineId, Long memberId) {
+        LocalCreator localCreator = localCreatorRepository.findByMemberId(memberId)
+            .orElseThrow(() -> new CustomException(ErrorCode.LOCAL_CREATOR_NOT_FOUND));
+
+        return magazineFeedbackRepository.findByMagazineIdAndLocalCreatorId(magazineId, localCreator.getId())
+            .stream()
+            .map(MagazineFeedbackResponseDto::new)
+            .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/salayo/locallifebackend/global/error/ErrorCode.java
+++ b/src/main/java/com/salayo/locallifebackend/global/error/ErrorCode.java
@@ -40,6 +40,7 @@ public enum ErrorCode {
     CANNOT_DELETE_ACTIVE_RESERVATION_EXIST(HttpStatus.BAD_REQUEST, "진행중인 예약이 있어 삭제할 수 없습니다."),
     PROGRAM_DELETED(HttpStatus.BAD_REQUEST, "삭제된 체험 프로그램입니다."),
     APTITUDE_TEST_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "적성 검사는 최대 5회까지만 가능합니다."),
+    FEEDBACK_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "피드백은 최대 3회까지만 작성할 수 있습니다."),
 
     // 401 Unauthorized
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),

--- a/src/main/resources/http/magazine.http
+++ b/src/main/resources/http/magazine.http
@@ -102,3 +102,6 @@ Authorization: Bearer {{accessToken}}
   "content": "네 번째 피드백 시도입니다."
 }
 
+### 매거진 피드백 목록 조회 (로컬 크리에이터)
+GET http://localhost:8080/magazines/1/feedbacks
+Authorization: Bearer {{accessToken}}

--- a/src/main/resources/http/magazine.http
+++ b/src/main/resources/http/magazine.http
@@ -68,3 +68,37 @@ Authorization: Bearer {{accessToken}}
 POST http://localhost:8080/admin/magazines/8/preview/send
 Authorization: Bearer {{accessToken}}
 Content-Type: application/json
+
+### 로컬 크리에이터 로그인 (승인 여부 확인 포함)
+POST http://localhost:8080/auth/login
+Content-Type: application/json
+
+{
+  "email": "creator1@example.com",
+  "password": "Password123!"
+}
+
+> {%
+  const json = response.body;
+  const accessToken = json.data.accessToken;
+  client.global.set("accessToken", accessToken);
+%}
+
+### 매거진 피드백 등록 성공
+POST http://localhost:8080/magazines/1/feedbacks
+Content-Type: application/json
+Authorization: Bearer {{accessToken}}
+
+{
+  "content": "첫 번째 수정 요청입니다. 본문 일부 문장을 조금 더 간결하게 다듬어주세요."
+}
+
+### 매거진 피드백 등록 실패 (최대 3회 초과)
+POST http://localhost:8080/magazines/1/feedbacks
+Content-Type: application/json
+Authorization: Bearer {{accessToken}}
+
+{
+  "content": "네 번째 피드백 시도입니다."
+}
+

--- a/src/main/resources/http/magazine.http
+++ b/src/main/resources/http/magazine.http
@@ -85,7 +85,7 @@ Content-Type: application/json
 %}
 
 ### 매거진 피드백 등록 성공
-POST http://localhost:8080/magazines/1/feedbacks
+POST http://localhost:8080/localcreator/magazines/8/feedbacks
 Content-Type: application/json
 Authorization: Bearer {{accessToken}}
 
@@ -94,7 +94,7 @@ Authorization: Bearer {{accessToken}}
 }
 
 ### 매거진 피드백 등록 실패 (최대 3회 초과)
-POST http://localhost:8080/magazines/1/feedbacks
+POST http://localhost:8080/localcreator/magazines/1/feedbacks
 Content-Type: application/json
 Authorization: Bearer {{accessToken}}
 
@@ -103,5 +103,5 @@ Authorization: Bearer {{accessToken}}
 }
 
 ### 매거진 피드백 목록 조회 (로컬 크리에이터)
-GET http://localhost:8080/magazines/1/feedbacks
+GET http://localhost:8080/localcreator/magazines/8/feedbacks
 Authorization: Bearer {{accessToken}}


### PR DESCRIPTION
-MagazineFeedback 엔티티 및 Repository 추가
-피드백 작성 시 revisionCount 자동 증가
-피드백은 최대 3회까지 제한(FEEDBACK_LIMIT_EXCEEDED 예외 처리)
-Swagger 문서화 및 테스트용 http 파일 작성