### PR TITLE
:sparkles: feat : 로컬크리에이터 마이페이지 기능 구현

### DIFF
--- a/src/main/java/com/salayo/locallifebackend/domain/admin/service/AdminService.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/admin/service/AdminService.java
@@ -8,6 +8,7 @@ import com.salayo.locallifebackend.domain.localcreator.dto.LocalCreatorEmailSear
 import com.salayo.locallifebackend.domain.localcreator.entity.LocalCreator;
 import com.salayo.locallifebackend.domain.localcreator.enums.CreatorStatus;
 import com.salayo.locallifebackend.domain.localcreator.repository.LocalCreatorRepository;
+import com.salayo.locallifebackend.global.enums.DeletedStatus;
 import com.salayo.locallifebackend.global.error.ErrorCode;
 import com.salayo.locallifebackend.global.error.exception.CustomException;
 import java.time.Duration;
@@ -38,7 +39,7 @@ public class AdminService {
     }
 
     public List<CreatorPendingResponseDto> getPendingCreators() {
-        return localCreatorRepository.findAllByCreatorStatus(CreatorStatus.PENDING).stream()
+        return localCreatorRepository.findAllActiveByCreatorStatus(CreatorStatus.PENDING, DeletedStatus.DISPLAYED).stream()
             .map(CreatorPendingResponseDto::from)
             .collect(Collectors.toList());
     }

--- a/src/main/java/com/salayo/locallifebackend/domain/file/repository/FileMappingRepository.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/file/repository/FileMappingRepository.java
@@ -26,4 +26,6 @@ public interface FileMappingRepository extends JpaRepository<FileMapping, Long> 
             "WHERE f.file.storedFileName = :url AND f.referenceId = 0")
     int updateReferenceIdByStoredFileNameAndZeroReference(@Param("url") String url, @Param("magazineId") Long magazineId);
 
+    void deleteAllByReferenceIdAndFileCategory(Long referenceId, FileCategory fileCategory);
+
 }

--- a/src/main/java/com/salayo/locallifebackend/domain/localcreator/controller/LocalCreatorController.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/localcreator/controller/LocalCreatorController.java
@@ -1,8 +1,13 @@
 package com.salayo.locallifebackend.domain.localcreator.controller;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.salayo.locallifebackend.domain.file.enums.FilePurpose;
 import com.salayo.locallifebackend.domain.localcreator.dto.LocalCreatorDetailResponseDto;
+import com.salayo.locallifebackend.domain.localcreator.dto.LocalCreatorUpdateRequestDto;
 import com.salayo.locallifebackend.domain.localcreator.service.LocalCreatorService;
 import com.salayo.locallifebackend.global.dto.CommonResponseDto;
+import com.salayo.locallifebackend.global.error.ErrorCode;
+import com.salayo.locallifebackend.global.error.exception.CustomException;
 import com.salayo.locallifebackend.global.security.MemberDetails;
 import com.salayo.locallifebackend.global.success.SuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
@@ -11,11 +16,18 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/localcreator/me")
@@ -50,6 +62,51 @@ public class LocalCreatorController {
         LocalCreatorDetailResponseDto localCreatorDetailResponseDto = localCreatorService.getMyCreatorInfo(memberId);
 
         return ResponseEntity.ok(CommonResponseDto.success(SuccessCode.FETCH_SUCCESS, localCreatorDetailResponseDto));
+    }
+
+    @PatchMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(
+        summary = "로컬 크리에이터 정보 수정 (+ 재승인 요청)",
+        description = """
+            마이페이지에서 로컬 크리에이터의 상호명, 사업장 주소, 증빙자료를 수정합니다.
+            수정 시 로컬 크리에이터 상태는 PENDING(재승인 대기)으로 변경되며,
+            관리자의 재승인 이후부터 다시 체험 등록 등의 기능을 사용할 수 있습니다.
+            """
+    )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "수정 및 재승인 요청 성공",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = CommonResponseDto.class))),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청 값"),
+        @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+        @ApiResponse(responseCode = "404", description = "로컬 크리에이터 조회 실패"),
+        @ApiResponse(responseCode = "409", description = "필수 증빙자료 누락 등으로 인한 충돌")
+    })
+    public ResponseEntity<CommonResponseDto<LocalCreatorDetailResponseDto>> updateMyCreatorInfo(
+        @AuthenticationPrincipal MemberDetails memberDetails,
+        @RequestPart("data") String requestDtoString,
+        @RequestPart("file") List<MultipartFile> files,
+        @RequestParam("filePurposes") List<String> filePurposesStrings
+    ) {
+        Long memberId = memberDetails.getMember().getId();
+
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        LocalCreatorUpdateRequestDto localCreatorUpdateRequestDto;
+        try {
+            localCreatorUpdateRequestDto = objectMapper.readValue(requestDtoString, LocalCreatorUpdateRequestDto.class);
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.INVALID_PARAMETER);
+        }
+
+        List<FilePurpose> filePurposes = filePurposesStrings.stream()
+            .map(FilePurpose::valueOf)
+            .collect(Collectors.toList());
+
+        LocalCreatorDetailResponseDto localCreatorDetailResponseDto = localCreatorService.updateMyCreatorInfo(memberId,
+            localCreatorUpdateRequestDto, files, filePurposes);
+
+        return ResponseEntity.ok(CommonResponseDto.success(SuccessCode.UPDATE_SUCCESS, localCreatorDetailResponseDto));
     }
 
 }

--- a/src/main/java/com/salayo/locallifebackend/domain/localcreator/controller/LocalCreatorController.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/localcreator/controller/LocalCreatorController.java
@@ -1,5 +1,55 @@
 package com.salayo.locallifebackend.domain.localcreator.controller;
 
+import com.salayo.locallifebackend.domain.localcreator.dto.LocalCreatorDetailResponseDto;
+import com.salayo.locallifebackend.domain.localcreator.service.LocalCreatorService;
+import com.salayo.locallifebackend.global.dto.CommonResponseDto;
+import com.salayo.locallifebackend.global.security.MemberDetails;
+import com.salayo.locallifebackend.global.success.SuccessCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/localcreator/me")
+@Tag(name = "LocalCreator", description = "로컬 크리에이터 회원 개인 정보 관련 API")
 public class LocalCreatorController {
+
+    private final LocalCreatorService localCreatorService;
+
+    public LocalCreatorController(LocalCreatorService localCreatorService) {
+        this.localCreatorService = localCreatorService;
+    }
+
+    @GetMapping
+    @Operation(
+        summary = "로컬 크리에이터 정보 조회",
+        description = """
+            로그인한 로컬 크리에이터의 기본 정보를 조회합니다.
+            이메일, 사업자명, 주소, 전화번호, 생년월일, 증빙자료 presigned URL을 반환합니다.
+            """
+    )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "조회 성공",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = CommonResponseDto.class))),
+        @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+        @ApiResponse(responseCode = "404", description = "로컬 크리에이터 조회 실패")
+    })
+    public ResponseEntity<CommonResponseDto<LocalCreatorDetailResponseDto>> getMyCreatorInfo(
+        @AuthenticationPrincipal MemberDetails memberDetails
+    ) {
+        Long memberId = memberDetails.getMember().getId();
+        LocalCreatorDetailResponseDto localCreatorDetailResponseDto = localCreatorService.getMyCreatorInfo(memberId);
+
+        return ResponseEntity.ok(CommonResponseDto.success(SuccessCode.FETCH_SUCCESS, localCreatorDetailResponseDto));
+    }
 
 }

--- a/src/main/java/com/salayo/locallifebackend/domain/localcreator/dto/LocalCreatorUpdateRequestDto.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/localcreator/dto/LocalCreatorUpdateRequestDto.java
@@ -1,0 +1,14 @@
+package com.salayo.locallifebackend.domain.localcreator.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class LocalCreatorUpdateRequestDto {
+
+    @NotBlank(message = "상호명은 필수입니다.")
+    private String businessName;
+
+    @NotBlank(message = "사업장주소는 필수입니다.")
+    private String businessAddress;
+}

--- a/src/main/java/com/salayo/locallifebackend/domain/localcreator/entity/LocalCreator.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/localcreator/entity/LocalCreator.java
@@ -66,4 +66,11 @@ public class LocalCreator extends BaseEntity {
         this.rejectedReason = rejectedReason;
     }
 
+    public void requestReapprove(String businessName, String businessAddress) {
+        this.businessName = businessName;
+        this.businessAddress = businessAddress;
+        this.creatorStatus = CreatorStatus.PENDING;
+        this.rejectedReason = null;
+    }
+
 }

--- a/src/main/java/com/salayo/locallifebackend/domain/localcreator/repository/LocalCreatorRepository.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/localcreator/repository/LocalCreatorRepository.java
@@ -2,11 +2,11 @@ package com.salayo.locallifebackend.domain.localcreator.repository;
 
 import com.salayo.locallifebackend.domain.localcreator.entity.LocalCreator;
 import com.salayo.locallifebackend.domain.localcreator.enums.CreatorStatus;
+import com.salayo.locallifebackend.global.enums.DeletedStatus;
 import com.salayo.locallifebackend.global.error.ErrorCode;
 import com.salayo.locallifebackend.global.error.exception.CustomException;
 import java.util.List;
 import java.util.Optional;
-import org.springframework.cglib.core.Local;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -33,5 +33,14 @@ public interface LocalCreatorRepository extends JpaRepository<LocalCreator, Long
     Optional<LocalCreator> findByMemberEmail(@Param("email") String email);
 
     boolean existsByMember_PhoneNumberAndMember_IdNot(String phoneNumber, Long id);
+
+    @Query("""
+        SELECT lc FROM LocalCreator lc
+        JOIN lc.member m
+        WHERE lc.creatorStatus = :status
+        AND m.deletedStatus = :deletedStatus
+        """)
+    List<LocalCreator> findAllActiveByCreatorStatus(@Param("status") CreatorStatus creatorStatus,
+        @Param("deletedStatus") DeletedStatus deletedStatus);
 
 }

--- a/src/main/java/com/salayo/locallifebackend/domain/localcreator/repository/LocalCreatorRepository.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/localcreator/repository/LocalCreatorRepository.java
@@ -24,6 +24,11 @@ public interface LocalCreatorRepository extends JpaRepository<LocalCreator, Long
             .orElseThrow(() -> new CustomException(ErrorCode.LOCAL_CREATOR_NOT_FOUND));
     }
 
+    default LocalCreator findByMemberIdOrThrow(Long memberId) {
+        return findByMemberId(memberId)
+            .orElseThrow(() -> new CustomException(ErrorCode.LOCAL_CREATOR_NOT_FOUND));
+    }
+
     @Query("SELECT lc FROM LocalCreator lc JOIN FETCH lc.member m WHERE m.email = :email")
     Optional<LocalCreator> findByMemberEmail(@Param("email") String email);
 

--- a/src/main/java/com/salayo/locallifebackend/domain/localcreator/service/LocalCreatorService.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/localcreator/service/LocalCreatorService.java
@@ -33,6 +33,16 @@ public class LocalCreatorService {
     public LocalCreatorDetailResponseDto getLocalCreatorDetail(Long localcreatorId) {
         LocalCreator localCreator = localCreatorRepository.findByIdOrThrow(localcreatorId);
 
+        return buildDetailResponse(localCreator);
+    }
+
+    public LocalCreatorDetailResponseDto getMyCreatorInfo(Long memberId){
+        LocalCreator localCreator = localCreatorRepository.findByMemberIdOrThrow(memberId);
+
+        return buildDetailResponse(localCreator);
+    }
+
+    private LocalCreatorDetailResponseDto buildDetailResponse(LocalCreator localCreator) {
         Member member = localCreator.getMember();
 
         List<FileMapping> fileMappings = fileMappingRepository

--- a/src/main/java/com/salayo/locallifebackend/domain/localcreator/service/LocalCreatorService.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/localcreator/service/LocalCreatorService.java
@@ -3,18 +3,26 @@ package com.salayo.locallifebackend.domain.localcreator.service;
 import com.salayo.locallifebackend.domain.file.entity.File;
 import com.salayo.locallifebackend.domain.file.entity.FileMapping;
 import com.salayo.locallifebackend.domain.file.enums.FileCategory;
+import com.salayo.locallifebackend.domain.file.enums.FilePurpose;
 import com.salayo.locallifebackend.domain.file.repository.FileMappingRepository;
+import com.salayo.locallifebackend.domain.file.repository.FileRepository;
 import com.salayo.locallifebackend.domain.file.util.S3Uploader;
 import com.salayo.locallifebackend.domain.localcreator.dto.LocalCreatorDetailResponseDto;
+import com.salayo.locallifebackend.domain.localcreator.dto.LocalCreatorUpdateRequestDto;
 import com.salayo.locallifebackend.domain.localcreator.entity.LocalCreator;
+import com.salayo.locallifebackend.domain.localcreator.enums.CreatorStatus;
 import com.salayo.locallifebackend.domain.localcreator.repository.LocalCreatorRepository;
 import com.salayo.locallifebackend.domain.member.entity.Member;
+import com.salayo.locallifebackend.global.error.ErrorCode;
+import com.salayo.locallifebackend.global.error.exception.CustomException;
 import java.net.URI;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 public class LocalCreatorService {
@@ -22,12 +30,14 @@ public class LocalCreatorService {
     private final LocalCreatorRepository localCreatorRepository;
     private final FileMappingRepository fileMappingRepository;
     private final S3Uploader s3Uploader;
+    private final FileRepository fileRepository;
 
     public LocalCreatorService(LocalCreatorRepository localCreatorRepository, FileMappingRepository fileMappingRepository,
-        S3Uploader s3Uploader) {
+        S3Uploader s3Uploader, FileRepository fileRepository) {
         this.localCreatorRepository = localCreatorRepository;
         this.fileMappingRepository = fileMappingRepository;
         this.s3Uploader = s3Uploader;
+        this.fileRepository = fileRepository;
     }
 
     public LocalCreatorDetailResponseDto getLocalCreatorDetail(Long localcreatorId) {
@@ -36,7 +46,7 @@ public class LocalCreatorService {
         return buildDetailResponse(localCreator);
     }
 
-    public LocalCreatorDetailResponseDto getMyCreatorInfo(Long memberId){
+    public LocalCreatorDetailResponseDto getMyCreatorInfo(Long memberId) {
         LocalCreator localCreator = localCreatorRepository.findByMemberIdOrThrow(memberId);
 
         return buildDetailResponse(localCreator);
@@ -76,7 +86,9 @@ public class LocalCreatorService {
     }
 
     private String extractKey(String storedFileName) {
-        if (storedFileName == null) return "";
+        if (storedFileName == null) {
+            return "";
+        }
         if (storedFileName.startsWith("http")) {
 
             try {
@@ -87,16 +99,70 @@ public class LocalCreatorService {
                 return storedFileName;
             }
         }
-            return storedFileName;
+        return storedFileName;
     }
 
 
     private String getFileType(String fileName) {
-        if (fileName == null) return "UNKNOWN";
+        if (fileName == null) {
+            return "UNKNOWN";
+        }
         String ext = fileName.substring(fileName.lastIndexOf('.') + 1).toLowerCase();
-        if (List.of("jpg", "jpeg", "png", "gif", "bmp", "webp").contains(ext)) return "IMAGE";
-        if ("pdf".equals(ext)) return "PDF";
+        if (List.of("jpg", "jpeg", "png", "gif", "bmp", "webp").contains(ext)) {
+            return "IMAGE";
+        }
+        if ("pdf".equals(ext)) {
+            return "PDF";
+        }
         return "UNKNOWN";
+    }
+
+    @Transactional
+    public LocalCreatorDetailResponseDto updateMyCreatorInfo(Long memberId, LocalCreatorUpdateRequestDto localCreatorUpdateRequestDto,
+        List<MultipartFile> files, List<FilePurpose> filePurposes) {
+        LocalCreator localCreator = localCreatorRepository.findByMemberIdOrThrow(memberId);
+        Member member = localCreator.getMember();
+
+        if (localCreator.getCreatorStatus() == CreatorStatus.PENDING) {
+            throw new CustomException(ErrorCode.LOCAL_CREATOR_NOT_APPROVED);
+        }
+
+        localCreator.requestReapprove(localCreatorUpdateRequestDto.getBusinessName(), localCreatorUpdateRequestDto.getBusinessAddress());
+
+        fileMappingRepository.deleteAllByReferenceIdAndFileCategory(member.getId(), FileCategory.LOCAL_CREATOR);
+
+        for (int i = 0; i < filePurposes.size(); i++) {
+            FilePurpose filePurpose = filePurposes.get(i);
+            MultipartFile multipartFile = files.get(i);
+
+            if (filePurpose == FilePurpose.BANK_ACCOUNT_COPY && (multipartFile == null || multipartFile.isEmpty())) {
+                throw new CustomException(ErrorCode.MISSING_REQUIRED_FILE);
+            }
+
+            if (multipartFile == null || multipartFile.isEmpty()) {
+                continue;
+            }
+
+            String storeUrl = s3Uploader.upload(multipartFile, "local-creator");
+
+            File savedFile = fileRepository.save(
+                File.builder()
+                    .originalName(multipartFile.getOriginalFilename())
+                    .storedFileName(storeUrl)
+                    .build()
+            );
+
+            fileMappingRepository.save(
+                FileMapping.builder()
+                    .file(savedFile)
+                    .fileCategory(FileCategory.LOCAL_CREATOR)
+                    .referenceId(member.getId())
+                    .filePurpose(filePurpose)
+                    .build()
+            );
+        }
+
+        return buildDetailResponse(localCreator);
     }
 
 }

--- a/src/main/resources/http/admin.http
+++ b/src/main/resources/http/admin.http
@@ -3,8 +3,8 @@ POST http://localhost:8080/auth/login
 Content-Type: application/json
 
 {
-  "email": "Admin001@salayo.com",
-  "password": "Adminpass1@"
+  "email": "Admin003@salayo.com",
+  "password": "Adminpass3@"
 }
 
 > {%

--- a/src/main/resources/http/admin.http
+++ b/src/main/resources/http/admin.http
@@ -21,12 +21,15 @@ Authorization: Bearer {{accessToken}}
 GET http://localhost:8080/admin/localcreators/3
 Authorization: Bearer {{accessToken}}
 
-### 로컬 크리에이터 회원가입 승인
+### 로컬 크리에이터 승인
+# 로컬 크리에이터 회원가입 승인
+# 로컬 크리에이터 정보 수정 후 재승인
 PATCH http://localhost:8080/admin/localcreators/1/approve
 Authorization: Bearer {{accessToken}}
-Content-Type: application/json
 
 ### 로컬 크리에이터 거절
+# 로컬 크리에이터 회원가입 거절
+# 로컬 크리에이터 정보 수정 확인 후 거절
 PATCH http://localhost:8080/admin/localcreators/2/reject
 Authorization: Bearer {{accessToken}}
 Content-Type: application/json

--- a/src/main/resources/http/localcreator.http
+++ b/src/main/resources/http/localcreator.http
@@ -16,3 +16,28 @@ Content-Type: application/json
 ### 로컬 크리에이터 정보 조회
 GET http://localhost:8080/localcreator/me
 Authorization: Bearer {{accessToken}}
+
+### 로컬 크리에이터 정보 수정 (+ 재승인 요청)
+# 실제 테스트는 Postman or Swagger
+PATCH http://localhost:8080/localcreator/me
+Authorization: Bearer {{accessToken}}
+Content-Type: multipart/form-data; boundary=----Boundary
+
+------Boundary
+Content-Disposition: form-data; name="data"
+Content-Type: application/json
+
+{
+  "businessName": "새로운 상호명",
+  "businessAddress": "서울시 어딘가 123-45"
+}
+------Boundary
+Content-Disposition: form-data; name="file"; filename="business_reg.png"
+Content-Type: image/png
+
+< ./files/business_reg.png
+------Boundary
+Content-Disposition: form-data; name="filePurposes"
+
+BUSINESS_REGISTRATION
+------Boundary--

--- a/src/main/resources/http/localcreator.http
+++ b/src/main/resources/http/localcreator.http
@@ -1,0 +1,18 @@
+### 로컬 크리에이터 로그인 (승인 여부 확인 포함)
+POST http://localhost:8080/auth/login
+Content-Type: application/json
+
+{
+  "email": "creator2@example.com",
+  "password": "Password123!"
+}
+
+> {%
+  const json = response.body;
+  const accessToken = json.data.accessToken;
+  client.global.set("accessToken", accessToken);
+%}
+
+### 로컬 크리에이터 정보 조회
+GET http://localhost:8080/localcreator/me
+Authorization: Bearer {{accessToken}}


### PR DESCRIPTION
1. 정보 조회
- presigned URL 포함된 증빙자료 조회
- email / businessName / businessAddress / phoneNumber / birth 전체 반환
- 승인 여부와 상관없이 본인만 조회 가능

2. 정보 수정 + 재승인 요청
- 상호명/주소 변경 + 증빙자료 재업로드
- 변경 즉시 PENDING 상태로 전환
- 기존 파일 전체 삭제 후 새로 저장
- 필수 파일 누락 예외 처리
- presigned URL 로 다시 조회 가능

3. 관리자 승인/거절 흐름 연동
- 기존에 사용하던 로직 재사용

4. 탈퇴한 로컬크리에이터 회원 로직 처리
- 삭제 상태인 회원은 로그인부터 차단
- LocalCreator 정보는 orphan 로 남겨도 조회 시 제외됨


----
## LocalCreator를 orphan(고아) 상태로 남기는 이유

### 1) 운영 이력 보존

로컬 크리에이터는 단순 회원이 아니라 승인·거절 이력이 존재하는 사업자 주체
탈퇴했다고 해서 제출 서류나 과거 승인 기록까지 삭제하면 관리자 입장에서 이력 추적이 불가능해져 운영 기록 용도로 정보만 남김

### 2) 참조 데이터 보호(무결성 문제 방지)

LocalCreator는 체험 프로그램, 후기 등 여러 도메인에서 참조될 수 있음
이를 삭제하면 외래키 문제와 데이터 무결성 오류가 발생할 위험이 있기 때문에 Member만 soft-delete 처리하여 로그인과 기능 사용은 막고, LocalCreator는 그대로 둬 참조 데이터 안정성을 유지
