### PR TITLE
:memo: docs : Admin·Email·Auth API Swagger 문서 정교화

### DIFF
--- a/src/main/java/com/salayo/locallifebackend/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/admin/controller/AdminController.java
@@ -9,6 +9,10 @@ import com.salayo.locallifebackend.domain.localcreator.service.LocalCreatorServi
 import com.salayo.locallifebackend.global.dto.CommonResponseDto;
 import com.salayo.locallifebackend.global.success.SuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -25,6 +29,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/admin")
 @Tag(name = "Admin", description = "관리자 관련 API")
+@PreAuthorize("hasRole('ADMIN')")
 public class AdminController {
 
     private final AdminService adminService;
@@ -35,8 +40,20 @@ public class AdminController {
         this.localCreatorService = localCreatorService;
     }
 
-    @Operation(summary = "승인 대기 로컬 크리에이터 목록 조회", description = "관리자가 승인 대기 중인 로컬 크리에이터의 목록을 볼 수 있습니다.")
-    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(
+        summary = "승인 대기 로컬 크리에이터 목록 조회",
+        description = """
+            관리자가 승인 대기 중인 로컬 크리에이터 목록을 조회합니다.
+            승인 상태(PENDING)인 신청자만 반환되며,
+            각 항목은 기본 정보와 제출 서류 상태를 포함합니다.
+            """
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "조회 성공",
+            content = @Content(schema = @Schema(implementation = CreatorPendingResponseDto.class))),
+        @ApiResponse(responseCode = "401", description = "인증 실패 (로그인이 필요함)"),
+        @ApiResponse(responseCode = "403", description = "권한 없음 (관리자만 접근 가능)"),
+    })
     @GetMapping("/localcreators")
     public ResponseEntity<CommonResponseDto<List<CreatorPendingResponseDto>>> getPendingCreators() {
         List<CreatorPendingResponseDto> creators = adminService.getPendingCreators();
@@ -44,8 +61,26 @@ public class AdminController {
         return ResponseEntity.ok(CommonResponseDto.success(SuccessCode.FETCH_SUCCESS, creators));
     }
 
-    @Operation(summary = "로컬크리에이터 회원가입 승인", description = "관리자가 로컬 크리에이터의 회원가입을 승인합니다.")
-    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(
+        summary = "로컬 크리에이터 요청 승인",
+        description = """
+            관리자가 로컬 크리에이터의 요청을 승인합니다.
+            
+            이 API는 다음 두 경우에 사용됩니다:
+            - 로컬 크리에이터의 최초 신청 요청 승인
+            - 정보 수정 후 재검토 요청 승인
+            
+            승인 가능한 상태는 'PENDING'뿐이며,
+            이미 승인 또는 거절된 요청은 다시 승인할 수 없습니다.
+            """
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "승인 성공"),
+        @ApiResponse(responseCode = "400", description = "이미 처리된 신청자"),
+        @ApiResponse(responseCode = "401", description = "인증 실패"),
+        @ApiResponse(responseCode = "403", description = "권한 없음"),
+        @ApiResponse(responseCode = "404", description = "로컬 크리에이터를 찾을 수 없음")
+    })
     @PatchMapping("/localcreators/{localcreatorId}/approve")
     public ResponseEntity<CommonResponseDto<Void>> approveCreator(@PathVariable Long localcreatorId) {
         adminService.approveCreator(localcreatorId);
@@ -53,12 +88,29 @@ public class AdminController {
         return ResponseEntity.ok(CommonResponseDto.success(SuccessCode.UPDATE_SUCCESS, null));
     }
 
-    @Operation(summary = "로컬크리에이터 회원가입 거절",
+    @Operation(
+        summary = "로컬 크리에이터 요청 거절",
         description = """
-            관리자가 로컬 크리에이터의 회원가입 신청을 거절합니다.
-            거절 사유를 입력하면 해당 회원의 상태가 '거절'로 변경되며, 거절 사유와 함께 재제출 안내 링크가 포함된 메일이 자동 발송됩니다.
-            """)
-    @PreAuthorize("hasRole('ADMIN')")
+            관리자가 로컬 크리에이터의 요청을 거절합니다.
+            
+            이 API는 다음 두 경우에 사용됩니다:
+            - 최초 신청 요청 거절
+            - 정보 수정 후 재검토 요청 최종 거절
+            
+            거절 사유(rejectReason)는 필수이며,
+            거절 시 다음 작업이 자동으로 수행됩니다:
+            - 요청 상태가 'REJECTED'로 변경됨
+            - 재제출 링크가 포함된 안내 메일 발송
+            - 재제출 토큰은 72시간 동안 유효
+            """
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "거절 처리 성공"),
+        @ApiResponse(responseCode = "400", description = "이미 처리된 신청자 / 잘못된 입력값"),
+        @ApiResponse(responseCode = "401", description = "인증 실패"),
+        @ApiResponse(responseCode = "403", description = "권한 없음"),
+        @ApiResponse(responseCode = "404", description = "로컬 크리에이터를 찾을 수 없음")
+    })
     @PatchMapping("/localcreators/{localcreatorId}/reject")
     public ResponseEntity<CommonResponseDto<Void>> rejectCreator(
         @PathVariable Long localcreatorId,
@@ -68,21 +120,46 @@ public class AdminController {
         return ResponseEntity.ok(CommonResponseDto.success(SuccessCode.UPDATE_SUCCESS, null));
     }
 
-    @Operation(summary = "로컬 크리에이터 신청 상세조회", description = "관리자가 로컬 크리에이터 회원가입 신청자의 기본정보 및 증빙파일(presigned URL 포함)을 조회합니다.")
-    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(
+        summary = "로컬 크리에이터 신청 상세 조회",
+        description = """
+            관리자가 로컬 크리에이터 회원가입 신청자의 상세 정보를 조회합니다.
+            반환값에는 기본 프로필 정보, 제출된 증빙 파일 목록,
+            각 파일에 대한 presigned URL이 포함됩니다.
+            """
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "조회 성공",
+            content = @Content(schema = @Schema(implementation = CommonResponseDto.class))),
+        @ApiResponse(responseCode = "401", description = "인증 실패"),
+        @ApiResponse(responseCode = "403", description = "관리자 권한 없음"),
+        @ApiResponse(responseCode = "404", description = "해당 신청자를 찾을 수 없음")
+    })
     @GetMapping("/localcreators/{localcreatorId}")
     public ResponseEntity<CommonResponseDto<LocalCreatorDetailResponseDto>> getLocalCreatorDetail(@PathVariable Long localcreatorId) {
         LocalCreatorDetailResponseDto responseDto = localCreatorService.getLocalCreatorDetail(localcreatorId);
 
-        return ResponseEntity.ok(CommonResponseDto.success(SuccessCode.FETCH_SUCCESS,responseDto));
+        return ResponseEntity.ok(CommonResponseDto.success(SuccessCode.FETCH_SUCCESS, responseDto));
     }
 
-    @Operation(summary = "이메일로 로컬 크리에이터 정보 조회", description = "입력된 이메일을 가진 로컬 크리에이터의 ID, 상호명, 이메일 정보를 반환합니다.")
-    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(
+        summary = "이메일로 로컬 크리에이터 정보 조회",
+        description = """
+            입력된 이메일을 가진 로컬 크리에이터의 기본 정보를 조회합니다.
+            반환값에는 ID, 상호명, 이메일이 포함됩니다.
+            """
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "조회 성공"),
+        @ApiResponse(responseCode = "400", description = "잘못된 이메일 형식"),
+        @ApiResponse(responseCode = "401", description = "인증 실패"),
+        @ApiResponse(responseCode = "403", description = "권한 없음"),
+        @ApiResponse(responseCode = "404", description = "해당 이메일의 신청자를 찾을 수 없음")
+    })
     @GetMapping("/localcreators/search")
     public ResponseEntity<CommonResponseDto<LocalCreatorEmailSearchResponseDto>> getLocalCreatorByEmail(@RequestParam String email) {
         LocalCreatorEmailSearchResponseDto emailSearchResponseDto = adminService.findLocalCreatorByEmail(email);
 
-        return ResponseEntity.ok(CommonResponseDto.success(SuccessCode.FETCH_SUCCESS,emailSearchResponseDto));
+        return ResponseEntity.ok(CommonResponseDto.success(SuccessCode.FETCH_SUCCESS, emailSearchResponseDto));
     }
 }

--- a/src/main/java/com/salayo/locallifebackend/domain/email/controller/EmailController.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/email/controller/EmailController.java
@@ -6,6 +6,10 @@ import com.salayo.locallifebackend.domain.email.service.EmailService;
 import com.salayo.locallifebackend.global.dto.CommonResponseDto;
 import com.salayo.locallifebackend.global.success.SuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -18,21 +22,57 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/auth/email")
-@Tag(name = "Email", description = "이메일 관련 API")
+@Tag(name = "Email", description = "이메일 인증 관련 API")
 public class EmailController {
 
     private final EmailService emailService;
 
+    @Operation(
+        summary = "이메일 인증 코드 전송",
+        description = """
+            회원가입 과정에서 사용자의 이메일로 인증 코드를 전송합니다.
+            
+            - 인증 코드는 6자리 숫자로 구성됩니다.
+            - 유효기간은 5분입니다.
+            - 이메일이 이미 인증된 상태일 경우 기존 인증 상태는 초기화됩니다.
+            - 과도한 요청 발생 시 차단될 수 있습니다.
+            """
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "인증 코드 전송 성공",
+            content = @Content(schema = @Schema(implementation = CommonResponseDto.class))),
+        @ApiResponse(responseCode = "400", description = "잘못된 이메일 형식"),
+        @ApiResponse(responseCode = "429", description = "요청 횟수 초과")
+    })
     @PostMapping("/send")
-    @Operation(summary = "회원가입 시 이메일 인증 코드 전송", description = "회원가입 시 사용자의 이메일로 인증 코드를 전송합니다. 인증코드는 5분간 유효합니다.")
-    public ResponseEntity<CommonResponseDto<Void>> sendVerificationCode(@RequestBody EmailSendRequestDto requestDto) {
+    public ResponseEntity<CommonResponseDto<Void>> sendVerificationCode(@Valid @RequestBody EmailSendRequestDto requestDto) {
         emailService.sendVerificationCode(requestDto.getEmail());
 
         return ResponseEntity.ok(CommonResponseDto.success(SuccessCode.EMAIL_SEND_SUCCESS, null));
     }
 
+    @Operation(
+        summary = "이메일 인증 코드 확인",
+        description = """
+            사용자가 입력한 이메일과 인증 코드를 비교하여 인증 여부를 확인합니다.
+            
+            다음과 같은 경우 인증에 실패할 수 있습니다:
+            - 인증 코드가 만료됨 (5분 유효)
+            - 인증 코드가 존재하지 않음
+            - 인증 코드가 일치하지 않음
+            
+            인증 성공 시:
+            - email_verified:{email} 플래그가 Redis에 저장되며, 30분 동안 유효합니다.
+            - 인증 코드는 즉시 삭제되어 재사용이 불가능합니다.
+            """
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "인증 성공",
+            content = @Content(schema = @Schema(implementation = CommonResponseDto.class))),
+        @ApiResponse(responseCode = "400", description = "잘못된 인증 코드 또는 이메일 형식"),
+        @ApiResponse(responseCode = "404", description = "인증 코드가 존재하지 않거나 만료됨")
+    })
     @PostMapping("/verify")
-    @Operation(summary = "회원가입 시 이메일 인증 코드 확인", description = "회원가입 시 이메일과 인증 코드를 비교하여 인증 여부를 확인합니다.")
     public ResponseEntity<CommonResponseDto<Void>> verifyEmailCode(@Valid @RequestBody EmailVerifyRequestDto requestDto) {
         emailService.verifyEmailCode(requestDto.getEmail(), requestDto.getCode());
 

--- a/src/main/java/com/salayo/locallifebackend/domain/member/controller/AuthController.java
+++ b/src/main/java/com/salayo/locallifebackend/domain/member/controller/AuthController.java
@@ -17,6 +17,8 @@ import com.salayo.locallifebackend.global.error.exception.CustomException;
 import com.salayo.locallifebackend.global.security.jwt.JwtProvider;
 import com.salayo.locallifebackend.global.success.SuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
@@ -46,7 +48,22 @@ public class AuthController {
         this.jwtProvider = jwtProvider;
     }
 
-    @Operation(summary = "일반회원 회원가입", description = "일반 사용자의 회원가입입니다.")
+    @Operation(
+        summary = "일반회원 회원가입",
+        description = """
+            일반 사용자의 회원가입 API입니다.
+            
+            처리 과정:
+            - 이메일 인증이 완료된 사용자만 가입이 가능합니다.
+            - 닉네임이 비어 있으면 랜덤 닉네임이 자동 생성됩니다.
+            - 이메일/닉네임 중복 시 가입이 불가능합니다.
+            """
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "201", description = "회원가입 성공"),
+        @ApiResponse(responseCode = "400", description = "이메일 인증 미완료 또는 잘못된 입력값"),
+        @ApiResponse(responseCode = "409", description = "중복 이메일 또는 닉네임")
+    })
     @PostMapping("/signup/user")
     public ResponseEntity<CommonResponseDto<UserSignupResponseDto>> signupUser(
         @RequestBody @Valid UserSignupRequestDto userSignupRequestDto) {
@@ -56,7 +73,28 @@ public class AuthController {
         return ResponseEntity.status(HttpStatus.CREATED).body(CommonResponseDto.success(SuccessCode.SIGNUP_SUCCESS, responseDto));
     }
 
-    @Operation(summary = "로컬크리에이터 회원가입", description = "로컬 크리에이터의 회원가입입니다.")
+    @Operation(
+        summary = "로컬 크리에이터 회원가입",
+        description = """
+            로컬 크리에이터 회원가입 API입니다.
+            multipart/form-data 형식으로 제출되며 다음 정보를 포함합니다.
+
+            - data: LocalCreatorSignupRequestDto(JSON)
+            - file: 증빙 파일 리스트
+            - filePurposes: 각 파일의 목적 (FilePurpose ENUM)
+            
+            유효성 조건:
+            - 이메일 인증 완료 필수
+            - 이메일 중복 불가
+            - 파일 개수와 목적 개수 일치 여부 검증
+            - 필수 파일(BANK_ACCOUNT_COPY) 누락 시 오류 발생
+            """
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "201", description = "회원가입 성공"),
+        @ApiResponse(responseCode = "400", description = "이메일 인증 미완료 / 잘못된 파일 구조"),
+        @ApiResponse(responseCode = "409", description = "이미 존재하는 이메일")
+    })
     @PostMapping(value = "/signup/localcreator", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<CommonResponseDto<LocalCreatorSignupResponseDto>> signupLocalCreator(
         @RequestPart("data") String requestDtoString,
@@ -85,7 +123,22 @@ public class AuthController {
         return ResponseEntity.status(HttpStatus.CREATED).body(CommonResponseDto.success(SuccessCode.SIGNUP_SUCCESS, responseDto));
     }
 
-    @Operation(summary = "로그인", description = "일반회원/로컬크리에이터 로그인입니다.")
+    @Operation(
+        summary = "로그인",
+        description = """
+            일반회원 및 로컬 크리에이터의 로그인 API입니다.
+            
+            - 이메일/비밀번호가 일치해야 합니다.
+            - 로컬 크리에이터는 관리자 승인(Approved) 상태여야 로그인 가능합니다.
+            - 성공 시 AccessToken 및 RefreshToken을 반환합니다.
+            """
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "로그인 성공"),
+        @ApiResponse(responseCode = "400", description = "잘못된 로그인 정보"),
+        @ApiResponse(responseCode = "403", description = "로컬 크리에이터 승인 미완료"),
+        @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
+    })
     @PostMapping("/login")
     public ResponseEntity<CommonResponseDto<LoginResponseDto>> login(
         @RequestBody @Valid LoginRequestDto requestDto) {
@@ -96,7 +149,23 @@ public class AuthController {
 
     }
 
-    @Operation(summary = "로그아웃", description = "JWT 액세스 토큰을 블랙리스트에 등록하여 로그아웃 처리합니다.")
+    @Operation(
+        summary = "로그아웃",
+        description = """
+            로그아웃 시 사용 중인 AccessToken은 '블랙리스트'로 처리되며,
+            토큰이 만료되기 전까지 재사용이 불가능합니다.
+            
+            처리 과정:
+            - RefreshToken 삭제
+            - AccessToken 삭제
+            - AccessToken을 Redis 블랙리스트에 저장
+            """
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "로그아웃 성공"),
+        @ApiResponse(responseCode = "400", description = "잘못된 토큰"),
+        @ApiResponse(responseCode = "401", description = "만료되거나 유효하지 않은 토큰")
+    })
     @PostMapping("/logout")
     public ResponseEntity<CommonResponseDto<Void>> logout(HttpServletRequest httpServletRequest) {
 
@@ -108,7 +177,20 @@ public class AuthController {
         return ResponseEntity.ok(CommonResponseDto.success(SuccessCode.LOGOUT_SUCCESS, null));
     }
 
-    @Operation(summary = "비밀번호 재설정 인증 코드 발송", description = "가입된 이메일로 비밀번호 재설정 인증코드를 보냅니다.")
+    @Operation(
+        summary = "비밀번호 재설정 인증코드 발송",
+        description = """
+            가입된 이메일로 비밀번호 재설정 인증 코드를 전송합니다.
+            
+            - 인증 코드는 6자리 숫자입니다.
+            - 인증 코드는 5분 동안 유효합니다.
+            - 인증 성공 전까지 비밀번호 재설정은 불가합니다.
+            """
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "인증 코드 전송 성공"),
+        @ApiResponse(responseCode = "404", description = "해당 이메일의 회원을 찾을 수 없음")
+    })
     @PostMapping("/password/send")
     public ResponseEntity<CommonResponseDto<Void>> sendPasswordResetCode(@RequestBody @Valid PasswordResetRequestDto resetRequestDto) {
         authService.sendPasswordResetCode(resetRequestDto.getEmail());
@@ -116,7 +198,22 @@ public class AuthController {
         return ResponseEntity.ok(CommonResponseDto.success(SuccessCode.EMAIL_SEND_SUCCESS, null));
     }
 
-    @Operation(summary = "비밀번호를 모르는 경우 비밀번호 재설정", description = "이메일로 받은 인증코드와 새 비밀번호를 입력해 비밀번호를 재설정합니다.")
+    @Operation(
+        summary = "비밀번호 재설정",
+        description = """
+            비밀번호를 모르는 경우 사용하는 재설정 API입니다.
+            
+            처리 과정:
+            - 이메일로 발송된 인증코드를 입력해야 합니다.
+            - 인증코드 일치 시 새 비밀번호로 즉시 변경됩니다.
+            - 기존 비밀번호와 동일한 비밀번호는 사용할 수 없습니다.
+            """
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "비밀번호 재설정 성공"),
+        @ApiResponse(responseCode = "400", description = "잘못된 코드 또는 기존 비밀번호와 동일"),
+        @ApiResponse(responseCode = "404", description = "인증 코드 만료 또는 이메일 없음")
+    })
     @PostMapping("/password/reset")
     public ResponseEntity<CommonResponseDto<Void>> resetPassword(@RequestBody @Valid PasswordResetVerifyRequestDto resetVerifyRequestDto) {
         authService.resetPassword(resetVerifyRequestDto);


### PR DESCRIPTION
##  작업 개요
Admin, Email, Auth 도메인의 Swagger 문서를 정교화하여  
API 사용 목적, 정상/예외 응답, 상태 변경 조건 등을 명확하게 정의했습니다.

##  주요 변경 사항
### 1. Admin 도메인
- 로컬 크리에이터 승인/거절 API 문서 상세화
- 승인/거절 상태 조건 및 예외 상황 명시
- Response 및 Error Code에 대한 설명 추가

### 2. Email 도메인
- 인증 코드 전송/검증 API 문서 구체화
- 인증 코드 유효시간, 재사용 불가, Redis 플래그 저장 로직 설명 추가
- 잘못된 요청/만료된 코드 등 예외 응답 문서화

### 3. Auth 도메인
- 일반 회원가입 / 로컬 크리에이터 회원가입 summary·description 보완
- Multipart 업로드 및 FilePurpose 매핑 설명 명확화
- 로그인 / 로그아웃 / 비밀번호 재설정 API 전체 문서 정리
- Redis 기반 토큰 블랙리스트 및 비밀번호 재설정 코드 처리 로직 설명

##  기타
- API 문서 가독성 향상
- 컨트롤러 함수별 역할 및 예외 흐름 명확화
